### PR TITLE
Replace use of serial with run_once

### DIFF
--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -7,10 +7,10 @@
     - prereqs
 
 - name: Include install tasks
-  ansible.builtin.include_tasks: tasks/install.yml
+  ansible.builtin.include_tasks: install.yml
 
 - name: Include systemd tasks
-  ansible.builtin.include_tasks: tasks/systemd.yml
+  ansible.builtin.include_tasks: systemd.yml
 
 - name: Link default logs directory
   ansible.builtin.file:

--- a/roles/keycloak/tasks/start_keycloak.yml
+++ b/roles/keycloak/tasks/start_keycloak.yml
@@ -1,0 +1,15 @@
+---
+- name: start keycloak
+  ansible.builtin.systemd:
+    name: keycloak
+    enabled: yes
+    state: started
+  become: yes
+
+- name: "Wait until Keycloak becomes active {{ keycloak.health_url }}"
+  ansible.builtin.uri:
+    url: "{{ keycloak.health_url }}"
+  register: keycloak_status
+  until: keycloak_status.status == 200
+  retries: 25
+  delay: 10

--- a/roles/keycloak/tasks/systemd.yml
+++ b/roles/keycloak/tasks/systemd.yml
@@ -1,4 +1,4 @@
-- name: configure keycloak service script wrapper
+- name: Configure keycloak service script wrapper
   become: yes
   ansible.builtin.template:
     src: keycloak-service.sh.j2
@@ -9,7 +9,7 @@
   notify:
     - restart keycloak
 
-- name: configure sysconfig file for keycloak service
+- name: Configure sysconfig file for keycloak service
   become: yes
   ansible.builtin.template:
     src: keycloak-sysconfig.j2
@@ -20,7 +20,7 @@
   notify:
     - restart keycloak
 
-- name: configure systemd unit file for keycloak service
+- name: Configure systemd unit file for keycloak service
   ansible.builtin.template:
     src: keycloak.service.j2
     dest: /etc/systemd/system/keycloak.service
@@ -32,18 +32,19 @@
   notify:
     - restart keycloak
 
-- name: reload systemd
+- name: Reload systemd
   become: yes
   ansible.builtin.systemd:
     daemon_reload: yes
   when: systemdunit.changed
 
-- name: start keycloak
-  ansible.builtin.systemd:
-    name: keycloak
-    enabled: yes
-    state: started
-  become: yes
+- name: Start and wait for keycloak service (first node db)
+  ansible.builtin.include_tasks: start_keycloak.yml
+  run_once: yes
+  when: keycloak_db_enabled
+
+- name: Start and wait for keycloak service (remaining nodes)
+  ansible.builtin.include_tasks: start_keycloak.yml
 
 - name: Check service status
   ansible.builtin.command: "systemctl status keycloak"
@@ -58,11 +59,3 @@
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
-
-- name: "Wait until Keycloak becomes active {{ keycloak.health_url }}"
-  ansible.builtin.uri:
-    url: "{{ keycloak.health_url }}"
-  register: keycloak_status
-  until: keycloak_status.status == 200
-  retries: 25
-  delay: 10

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -633,7 +633,7 @@
         <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:jboss}"/>
 {% if keycloak_modcluster.enabled %}    
         <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
-            <proxy name="default" advertise-socket="modcluster" listener="ajp" proxies="proxy1">
+            <proxy name="default" advertise="false" listener="ajp" proxies="proxy1">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>
@@ -744,7 +744,6 @@
         <socket-binding name="management-http" interface="management" port="{{ keycloak_management_http_port }}"/>
         <socket-binding name="management-https" interface="management" port="{{ keycloak_management_https_port }}"/>
         <socket-binding name="jgroups-tcp" interface="jgroups" port="{{ keycloak_jgroups_port }}"/>
-        <socket-binding name="modcluster" multicast-address="${jboss.modcluster.multicast.address:224.0.1.105}" multicast-port="23364"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>
         <outbound-socket-binding name="mail-smtp">

--- a/roles/keycloak/templates/standalone.xml.j2
+++ b/roles/keycloak/templates/standalone.xml.j2
@@ -546,7 +546,7 @@
         <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:jboss}"/>
 {% if keycloak_modcluster.enabled %}        
         <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
-            <proxy name="default" advertise-socket="modcluster" listener="ajp" proxies="proxy1">
+            <proxy name="default" advertise="false" listener="ajp" proxies="proxy1">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>
@@ -644,7 +644,6 @@
         <socket-binding name="https" port="{{ keycloak_https_port }}"/>
         <socket-binding name="management-http" interface="management" port="{{ keycloak_management_http_port }}"/>
         <socket-binding name="management-https" interface="management" port="{{ keycloak_management_https_port }}"/>
-        <socket-binding name="modcluster" multicast-address="${jboss.modcluster.multicast.address:224.0.1.105}" multicast-port="23364"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>
         <outbound-socket-binding name="mail-smtp">


### PR DESCRIPTION
run_once on first node when database config enabled (so the first
node creates the tables), then wakeup all other nodes

fixes #13 