### PR TITLE
Use become for tasks that will otherwise fail

### DIFF
--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -28,6 +28,7 @@
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
     mode: 0644
+  become: yes
   notify:
     - restart keycloak
 
@@ -38,6 +39,7 @@
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
     mode: 0644
+  become: yes
   notify:
     - restart keycloak    
 
@@ -48,6 +50,7 @@
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
     mode: 0775
+  become: yes
 
 - name: "Start and wait for keycloak service"
   ansible.builtin.include_tasks: start.yml
@@ -63,3 +66,4 @@
     src: "{{ keycloak.home }}/{{ keycloak.log.file | dirname }}"
     dest: /var/log/keycloak
     force: yes
+  become: yes


### PR DESCRIPTION
The modified tasks require sudo rights to be performed.
Running the whole playbook as sudo will fail on the tasks that are delegated to localhosts (unless you are actually running the playbook as root)