### PR TITLE
keycloak_quarkus: use absolute path for certificate files

### DIFF
--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -9,8 +9,8 @@
     keycloak_quarkus_http_relative_path: ''
     keycloak_quarkus_log: file
     keycloak_quarkus_https_enabled: True
-    keycloak_quarkus_key_file: conf/key.pem
-    keycloak_quarkus_cert_file: conf/cert.pem
+    keycloak_quarkus_key_file: "{{ keycloak.home }}/conf/key.pem"
+    keycloak_quarkus_cert_file: "{{ keycloak.home }}/conf/cert.pem"
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -37,8 +37,8 @@ Role Defaults
 |`keycloak_quarkus_http_relative_path` | Service context path | `auth` |
 |`keycloak_quarkus_http_enabled`| Enable listener on HTTP port | `True` |
 |`keycloak_quarkus_https_enabled`| Enable listener on HTTPS port | `False` |
-|`keycloak_quarkus_key_file`| The file path to a private key in PEM format | `conf/server.key.pem` |
-|`keycloak_quarkus_cert_file`| The file path to a server certificate or certificate chain in PEM format | `conf/server.crt.pem` |
+|`keycloak_quarkus_key_file`| The file path to a private key in PEM format | `{{ keycloak.home }}/conf/server.key.pem` |
+|`keycloak_quarkus_cert_file`| The file path to a server certificate or certificate chain in PEM format | `{{ keycloak.home }}/conf/server.crt.pem` |
 
 
 * Database configuration

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -36,8 +36,8 @@ keycloak_quarkus_java_opts: "-Xms1024m -Xmx2048m"
 
 ### TLS/HTTPS configuration
 keycloak_quarkus_https_enabled: False
-keycloak_quarkus_key_file: conf/server.key.pem
-keycloak_quarkus_cert_file: conf/server.crt.pem
+keycloak_quarkus_key_file: "{{ keycloak.home }}/conf/server.key.pem"
+keycloak_quarkus_cert_file: "{{ keycloak.home }}/conf/server.crt.pem"
 
 ### Enable configuration for database backend, clustering and remote caches on infinispan
 keycloak_quarkus_ha_enabled: False

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -108,11 +108,11 @@ argument_specs:
                 description: "Enable listener on HTTPS port"
                 type: "bool" 
             keycloak_quarkus_key_file:
-                default: "conf/server.key.pem"
+                default: "{{ keycloak.home }}/conf/server.key.pem"
                 description: "The file path to a private key in PEM format"
                 type: "str"
             keycloak_quarkus_cert_file:
-                default: "conf/server.crt.pem"
+                default: "{{ keycloak.home }}/conf/server.crt.pem"
                 description: "The file path to a server certificate or certificate chain in PEM format"
                 type: "str"
             keycloak_quarkus_https_port:

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -19,8 +19,8 @@ http-port={{ keycloak_quarkus_http_port }}
 # HTTPS
 https-port={{ keycloak_quarkus_https_port }}
 {% if keycloak_quarkus_https_enabled %}
-https-certificate-file={{ keycloak.home }}/{{ keycloak_quarkus_cert_file}}
-https-certificate-key-file={{ keycloak.home }}/{{ keycloak_quarkus_key_file }}
+https-certificate-file={{ keycloak_quarkus_cert_file}}
+https-certificate-key-file={{ keycloak_quarkus_key_file }}
 {% endif %}
 
 # Hostname for the Keycloak server.


### PR DESCRIPTION
If you want to use a certificate for both Keycloak and Nginx, the cert files are quite unlikely to be under `keycloak.home`
Even in case you want to keep the under Keycloak path, you can always define the variable:

```
   keycloak_quarkus_cert_file: "{{ keycloak.home }}/conf/my_keycloak_cert.pem"
   keycloak_quarkus_key_file: "{{ keycloak.home }}/conf/my_keycloak_key.pem"
```
This change will break your previous configuration (unless you use the default values).
To fix your config for the new changes, you will have use full paths for the 2 variables mentioned above. For example:
```
   keycloak_quarkus_key_file: "/etc/ssl/certs/my_keycloak_key.pem"
   keycloak_quarkus_cert_file: "/etc/ssl/certs/my_keycloak_cert.pem"
```