### PR TITLE
keycloak_quarkus: variable to enable development mode

### DIFF
--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -5,7 +5,7 @@
     keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_admin_password: "remembertochangeme"
     keycloak_realm: TestRealm
-    keycloak_quarkus_host: instance:8443
+    keycloak_quarkus_host: instance
     keycloak_quarkus_http_relative_path: ''
     keycloak_quarkus_log: file
     keycloak_quarkus_https_enabled: True

--- a/molecule/quarkus/verify.yml
+++ b/molecule/quarkus/verify.yml
@@ -25,10 +25,10 @@
         - name: Verify endpoint URLs
           assert:
             that:
-              - (openid_config.stdout | from_json)["backchannel_authentication_endpoint"] == 'https://instance:8443/realms/master/protocol/openid-connect/ext/ciba/auth'
-              - (openid_config.stdout | from_json)['issuer'] == 'https://instance:8443/realms/master'
-              - (openid_config.stdout | from_json)['authorization_endpoint'] == 'https://instance:8443/realms/master/protocol/openid-connect/auth'
-              - (openid_config.stdout | from_json)['token_endpoint'] == 'https://instance:8443/realms/master/protocol/openid-connect/token'
+              - (openid_config.stdout | from_json)["backchannel_authentication_endpoint"] == 'https://instance/realms/master/protocol/openid-connect/ext/ciba/auth'
+              - (openid_config.stdout | from_json)['issuer'] == 'https://instance/realms/master'
+              - (openid_config.stdout | from_json)['authorization_endpoint'] == 'https://instance/realms/master/protocol/openid-connect/auth'
+              - (openid_config.stdout | from_json)['token_endpoint'] == 'https://instance/realms/master/protocol/openid-connect/token'
           delegate_to: localhost
       when:
         - hera_home is defined

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -97,6 +97,7 @@ Role Defaults
 |`keycloak_quarkus_log_file`| Set the log file path and filename relative to keycloak home | `data/log/keycloak.log` |
 |`keycloak_quarkus_log_format`| Set a format specific to file log entries | `%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n` |
 |`keycloak_quarkus_proxy_mode`| The proxy address forwarding mode if the server is behind a reverse proxy | `edge` |
+|`keycloak_quarkus_start_dev`| Whether to start the service in development mode (start-dev) | `False` |
 
 
 Role Variables

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -14,6 +14,7 @@ keycloak_quarkus_java_home:
 keycloak_quarkus_dest: /opt/keycloak
 keycloak_quarkus_home: "{{ keycloak_quarkus_installdir }}"
 keycloak_quarkus_config_dir: "{{ keycloak_quarkus_home }}/conf"
+keycloak_quarkus_start_dev: False
 keycloak_quarkus_service_user: keycloak
 keycloak_quarkus_service_group: keycloak
 keycloak_quarkus_service_pidfile: "/run/keycloak.pid"

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -244,3 +244,7 @@ argument_specs:
                 default: 'edge'
                 type: "str"
                 description: "The proxy address forwarding mode if the server is behind a reverse proxy"
+            keycloak_quarkus_start_dev:
+                default: False
+                type: "bool"
+                description: "Whether to start the service in development mode (start-dev)"

--- a/roles/keycloak_quarkus/templates/keycloak.service.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.service.j2
@@ -7,7 +7,11 @@ After=network.target
 Type=simple
 EnvironmentFile=-/etc/sysconfig/keycloak
 PIDFile={{ keycloak_quarkus_service_pidfile }}
+{% if keycloak_quarkus_start_dev %}
+ExecStart={{ keycloak.home }}/bin/kc.sh start-dev
+{% else %}
 ExecStart={{ keycloak.home }}/bin/kc.sh start --auto-build --log={{ keycloak_quarkus_log }}
+{% endif %}
 User={{ keycloak.service_user }}
 
 [Install]

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -4,7 +4,7 @@ keycloak:
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "http://localhost:8080/realms/master/.well-known/openid-configuration"
+  health_url: "http://{{ keycloak_quarkus_host }}:{{keycloak_quarkus_http_port }}/realms/master/.well-known/openid-configuration"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"
   service_group: "{{ keycloak_quarkus_service_group }}"

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -4,7 +4,7 @@ keycloak:
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "http://{{ keycloak_quarkus_host }}:{{keycloak_quarkus_http_port }}/realms/master/.well-known/openid-configuration"
+  health_url: "http://{{ keycloak_quarkus_host }}:{{ keycloak_quarkus_http_port }}/realms/master/.well-known/openid-configuration"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"
   service_group: "{{ keycloak_quarkus_service_group }}"


### PR DESCRIPTION
- Enables keycloak_quarkus role to use keycloak in dev mode by setting "keycloak_quarkus_start_dev" to True
- Fixes the hardcoded health check url in keycloak_quarkus role