### PR TITLE
Allow overrides for service start retries and delay

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,6 +20,7 @@ tags:
   - security
   - infrastructure
   - authentication
+  - java
 dependencies:
   "middleware_automation.redhat_csp_download": ">=1.2.1"
   "community.general": ">=5.6.0"

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -2,7 +2,7 @@
 ### Configuration specific to keycloak
 keycloak_version: 18.0.2
 keycloak_archive: "keycloak-legacy-{{ keycloak_version }}.zip"
-keycloak_download_url: "https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/{{ keycloak_archive }}"  
+keycloak_download_url: "https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/{{ keycloak_archive }}"
 keycloak_download_url_9x: "https://downloads.jboss.org/keycloak/{{ keycloak_version }}/{{ keycloak_archive }}"
 keycloak_installdir: "{{ keycloak_dest }}/keycloak-{{ keycloak_version }}"
 keycloak_offline_install: False
@@ -21,6 +21,8 @@ keycloak_service_group: keycloak
 keycloak_service_pidfile: "/run/keycloak.pid"
 keycloak_service_name: keycloak
 keycloak_service_desc: Keycloak
+keycloak_service_start_delay: 10
+keycloak_service_start_retries: 25
 
 keycloak_configure_firewalld: False
 

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -266,6 +266,14 @@ argument_specs:
                 default: "Keycloak"
                 description: "systemd description for keycloak"
                 type: "str"
+            keycloak_service_start_delay:
+                default: "10"
+                description: "Expected delay in ms before the service is expected to be available after start."
+                type: "int"
+            keycloak_service_start_retries:
+                default: "25"
+                description: "How many time should Ansible retry to connect to the service after it was started, before failing."
+                type: "int"
             keycloak_no_log:
                 default: true
                 type: "bool"

--- a/roles/keycloak/tasks/restart_keycloak.yml
+++ b/roles/keycloak/tasks/restart_keycloak.yml
@@ -15,8 +15,8 @@
   until: keycloak_status.status == 200
   delegate_to: "{{ ansible_play_hosts | first }}"
   run_once: True
-  retries: 25
-  delay: 10
+  retries: "{{ keycloak_service_start_retries }}"
+  delay: "{{ keycloak_service_start_delay }}"
 
 - name: "Restart and enable {{ keycloak.service_name }} service"
   ansible.builtin.systemd:

--- a/roles/keycloak/tasks/start_keycloak.yml
+++ b/roles/keycloak/tasks/start_keycloak.yml
@@ -11,5 +11,5 @@
     url: "{{ keycloak.health_url }}"
   register: keycloak_status
   until: keycloak_status.status == 200
-  retries: 25
-  delay: 10
+  retries: "{{ keycloak_service_start_retries }}"
+  delay: "{{ keycloak_service_start_delay }}"


### PR DESCRIPTION
A small tweak, but I suspect many users we'll need to fine tune this depending on their env