### PR TITLE
Update keycloak.conf.j2

### DIFF
--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -30,7 +30,7 @@ hostname-path={{ keycloak_quarkus_http_relative_path }}
 # Cluster
 {% if keycloak_quarkus_ha_enabled %}
 cache=ispn
-cache-config-file=conf/cache-ispn.xml
+cache-config-file=cache-ispn.xml
 cache-stack=tcp
 {% endif %}
 


### PR DESCRIPTION
The documentation states that the path is relative to the /conf directory, which is true. So if one changes the contents of this file it would have no effect because the path would be non-existent. To make things worse, there would be no obvious error stating this and the configuration would be loaded from the defaults.