### PR TITLE
Provide config for multiple modcluster proxies

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,6 +4,12 @@
   vars: 
     keycloak_admin_password: "remembertochangeme"
     keycloak_jvm_package: java-11-openjdk-headless
+    keycloak_modcluster_enabled: True
+    keycloak_modcluster_urls:
+      - host: myhost1
+        port: 16667
+      - host: myhost2
+        port: 16668
   roles:
     - role: keycloak
   tasks:

--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -116,7 +116,9 @@ The following variables are _required_ only when `keycloak_ha_enabled` is True:
 
 | Variable | Description | Default |
 |:---------|:------------|:---------|
-|`keycloak_modcluster_url` | URL for the modcluster reverse proxy | `localhost` |
+|`keycloak_modcluster_url` | _deprecated_ Host for the modcluster reverse proxy | `localhost` |
+|`keycloak_modcluster_port` | _deprecated_ Port for the modcluster reverse proxy | `6666` |
+|`keycloak_modcluster_urls` | List of {host,port} dicts for the modcluster reverse proxies | `[ { localhost:6666 } ]` |
 |`keycloak_jdbc_engine` | backend database engine when db is enabled: [ postgres, mariadb ] | `postgres` |
 |`keycloak_infinispan_url` | URL for the infinispan remote-cache server | `localhost:11122` |
 |`keycloak_infinispan_user` | username for connecting to infinispan | `supervisor` |

--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -115,7 +115,8 @@ The following are a set of _required_ variables for the role:
 The following variables are _required_ only when `keycloak_ha_enabled` is True:
 
 | Variable | Description | Default |
-|:---------|:------------|:---------|
+|:---------|:------------|:--------|
+|`keycloak_modcluster_enabled`| Enable configuration for modcluster subsystem | `True` if `keycloak_ha_enabled` is True, else `False` |
 |`keycloak_modcluster_url` | _deprecated_ Host for the modcluster reverse proxy | `localhost` |
 |`keycloak_modcluster_port` | _deprecated_ Port for the modcluster reverse proxy | `6666` |
 |`keycloak_modcluster_urls` | List of {host,port} dicts for the modcluster reverse proxies | `[ { localhost:6666 } ]` |

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -54,8 +54,12 @@ keycloak_auth_client: admin-cli
 
 keycloak_force_install: False
 
-### mod_cluster reverse proxy
+### mod_cluster reverse proxy list
 keycloak_modcluster_url: localhost
+keycloak_modcluster_port: 6666
+keycloak_modcluster_urls:
+  - host: "{{ keycloak_modcluster_url }}"
+    port: "{{ keycloak_modcluster_port }}"
 
 ### keycloak frontend url
 keycloak_frontend_url: http://localhost:8080/auth

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -55,6 +55,7 @@ keycloak_auth_client: admin-cli
 keycloak_force_install: False
 
 ### mod_cluster reverse proxy list
+keycloak_modcluster_enabled: "{{ True if keycloak_ha_enabled else False }}"
 keycloak_modcluster_url: localhost
 keycloak_modcluster_port: 6666
 keycloak_modcluster_urls:

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -178,14 +178,10 @@ argument_specs:
                 default: "localhost"
                 description: "URL for the modcluster reverse proxy"
                 type: "str"
-                removed_in_version: "1.4.0"
-                removed_from_collection: "middleware_automation.keycloak"
             keycloak_modcluster_port:
                 default: 6666
                 description: "Port for the modcluster reverse proxy"
                 type: "int"
-                removed_in_version: "1.4.0"
-                removed_from_collection: "middleware_automation.keycloak"
             keycloak_modcluster_urls:
                 default: "[ { host: 'localhost', port: 6666 } ]"
                 description: "List of modproxy node URLs in the format { host, port } for the modcluster reverse proxy"

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -152,7 +152,7 @@ argument_specs:
                 # line 48 of keycloak/defaults/main.yml
                 default: "{{ True if keycloak_ha_enabled else False }}"
                 description: "Enable auto configuration for database backend"
-                type: "str"
+                type: "bool"
             keycloak_admin_user:
                 # line 51 of keycloak/defaults/main.yml
                 default: "admin"
@@ -172,6 +172,10 @@ argument_specs:
                 # line 55 of keycloak/defaults/main.yml
                 default: false
                 description: "Remove pre-existing versions of service"
+                type: "bool"
+            keycloak_modcluster_enabled:
+                default: "{{ True if keycloak_ha_enabled else False }}"
+                description: "Enable configuration for modcluster subsystem"
                 type: "bool"
             keycloak_modcluster_url:
                 # line 58 of keycloak/defaults/main.yml

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -178,6 +178,18 @@ argument_specs:
                 default: "localhost"
                 description: "URL for the modcluster reverse proxy"
                 type: "str"
+                removed_in_version: "1.4.0"
+                removed_from_collection: "middleware_automation.keycloak"
+            keycloak_modcluster_port:
+                default: 6666
+                description: "Port for the modcluster reverse proxy"
+                type: "int"
+                removed_in_version: "1.4.0"
+                removed_from_collection: "middleware_automation.keycloak"
+            keycloak_modcluster_urls:
+                default: "[ { host: 'localhost', port: 6666 } ]"
+                description: "List of modproxy node URLs in the format { host, port } for the modcluster reverse proxy"
+                type: "list"
             keycloak_frontend_url:
                 # line 59 of keycloak/defaults/main.yml
                 default: "http://localhost"

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 # tasks file for keycloak
-
 - name: Check prerequisites
   ansible.builtin.include_tasks: prereqs.yml
   tags:

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -617,7 +617,7 @@
         <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:jboss}"/>
 {% if keycloak_modcluster.enabled %}    
         <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
-            <proxy name="default" advertise="false" listener="ajp" proxies="proxy1">
+            <proxy name="default" advertise="false" listener="ajp" proxies="{{ ['proxy_'] | product(keycloak_modcluster.reverse_proxy_urls | map(attribute='host')) | map('join') | list | join(',') }}">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>
@@ -705,9 +705,11 @@
             <remote-destination host="${jboss.mail.server.host:localhost}" port="${jboss.mail.server.port:25}"/>
         </outbound-socket-binding>
 {% if keycloak_modcluster.enabled %}
-        <outbound-socket-binding name="proxy1">
-            <remote-destination host="{{ keycloak_modcluster.reverse_proxy_url | default('localhost') }}" port="6666"/>
+    {% for modcluster in keycloak_modcluster.reverse_proxy_urls %}
+        <outbound-socket-binding name="proxy_{{ modcluster.host }}">
+            <remote-destination host="{{ modcluster.host }}" port="{{ modcluster.port }}"/>
         </outbound-socket-binding>
+    {% endfor %}
 {% endif %}
         <outbound-socket-binding name="remote-cache">
             <remote-destination host="{{ keycloak_remotecache.server_name | default('localhost') }}" port="${remote.cache.port:11222}"/>

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -617,7 +617,7 @@
         <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:jboss}"/>
 {% if keycloak_modcluster.enabled %}    
         <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
-            <proxy name="default" advertise="false" listener="ajp" proxies="{{ ['proxy_'] | product(keycloak_modcluster.reverse_proxy_urls | map(attribute='host')) | map('join') | list | join(',') }}">
+            <proxy name="default" advertise="false" listener="ajp" proxies="{{ ['proxy_'] | product(keycloak_modcluster.reverse_proxy_urls | map(attribute='host')) | map('join') | list | join(' ') }}">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>
@@ -705,11 +705,11 @@
             <remote-destination host="${jboss.mail.server.host:localhost}" port="${jboss.mail.server.port:25}"/>
         </outbound-socket-binding>
 {% if keycloak_modcluster.enabled %}
-    {% for modcluster in keycloak_modcluster.reverse_proxy_urls %}
+{% for modcluster in keycloak_modcluster.reverse_proxy_urls %}
         <outbound-socket-binding name="proxy_{{ modcluster.host }}">
             <remote-destination host="{{ modcluster.host }}" port="{{ modcluster.port }}"/>
         </outbound-socket-binding>
-    {% endfor %}
+{% endfor %}
 {% endif %}
         <outbound-socket-binding name="remote-cache">
             <remote-destination host="{{ keycloak_remotecache.server_name | default('localhost') }}" port="${remote.cache.port:11222}"/>

--- a/roles/keycloak/templates/standalone.xml.j2
+++ b/roles/keycloak/templates/standalone.xml.j2
@@ -530,7 +530,7 @@
         <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:jboss}"/>
 {% if keycloak_modcluster.enabled %}        
         <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
-            <proxy name="default" advertise="false" listener="ajp" proxies="{{ ['proxy_'] | product(keycloak_modcluster.reverse_proxy_urls | map(attribute='host')) | map('join') | list | join(',') }}">
+            <proxy name="default" advertise="false" listener="ajp" proxies="{{ ['proxy_'] | product(keycloak_modcluster.reverse_proxy_urls | map(attribute='host')) | map('join') | list | join(' ') }}">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>
@@ -604,12 +604,12 @@
         <outbound-socket-binding name="mail-smtp">
             <remote-destination host="${jboss.mail.server.host:localhost}" port="${jboss.mail.server.port:25}"/>
         </outbound-socket-binding>
-{% if keycloak_modcluster.enabled %}        
-    {% for modcluster in keycloak_modcluster.reverse_proxy_urls %}
+{% if keycloak_modcluster.enabled %}
+{% for modcluster in keycloak_modcluster.reverse_proxy_urls %}
         <outbound-socket-binding name="proxy_{{ modcluster.host }}">
             <remote-destination host="{{ modcluster.host }}" port="{{ modcluster.port }}"/>
         </outbound-socket-binding>
-    {% endfor %}
+{% endfor %}
 {% endif %}        
     </socket-binding-group>
 </server>

--- a/roles/keycloak/templates/standalone.xml.j2
+++ b/roles/keycloak/templates/standalone.xml.j2
@@ -530,7 +530,7 @@
         <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:jboss}"/>
 {% if keycloak_modcluster.enabled %}        
         <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
-            <proxy name="default" advertise="false" listener="ajp" proxies="proxy1">
+            <proxy name="default" advertise="false" listener="ajp" proxies="{{ ['proxy_'] | product(keycloak_modcluster.reverse_proxy_urls | map(attribute='host')) | map('join') | list | join(',') }}">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>
@@ -605,9 +605,11 @@
             <remote-destination host="${jboss.mail.server.host:localhost}" port="${jboss.mail.server.port:25}"/>
         </outbound-socket-binding>
 {% if keycloak_modcluster.enabled %}        
-        <outbound-socket-binding name="proxy1">
-            <remote-destination host="{{ keycloak_modcluster.reverse_proxy_url | default('localhost') }}" port="6666"/>
+    {% for modcluster in keycloak_modcluster.reverse_proxy_urls %}
+        <outbound-socket-binding name="proxy_{{ modcluster.host }}">
+            <remote-destination host="{{ modcluster.host }}" port="{{ modcluster.port }}"/>
         </outbound-socket-binding>
+    {% endfor %}
 {% endif %}        
     </socket-binding-group>
 </server>

--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -59,7 +59,7 @@ keycloak_jdbc:
 
 # reverse proxy mod_cluster
 keycloak_modcluster:
-  enabled: "{{ keycloak_ha_enabled }}"
+  enabled: "{{ keycloak_ha_enabled or keycloak_modcluster_enabled }}"
   reverse_proxy_urls: "{{ keycloak_modcluster_urls }}"
   frontend_url: "{{ keycloak_frontend_url }}"
 

--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -60,7 +60,7 @@ keycloak_jdbc:
 # reverse proxy mod_cluster
 keycloak_modcluster:
   enabled: "{{ keycloak_ha_enabled }}"
-  reverse_proxy_url: "{{ keycloak_modcluster_url }}"
+  reverse_proxy_urls: "{{ keycloak_modcluster_urls }}"
   frontend_url: "{{ keycloak_frontend_url }}"
 
 # infinispan


### PR DESCRIPTION
Provide a new variable:

| Variable | Description | Default |
|:---------|:------------|:---------|
|`keycloak_modcluster_urls` | List of {host,port} dicts for the modcluster reverse proxies | `[ { localhost:6666 } ]` |

that allows to setup multiple reverse proxy instances for the modcluster subsystem.

The variables `keycloak_modcluster_url` and `keycloak_modcluster_port` are now _deprecated_ and will be removed in the next major release.

Also provide a variable:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_modcluster_enabled`| Enable configuration for modcluster subsystem | `True` if `keycloak_ha_enabled` is True, else `False` |

which allows to turn on the modcluster configuration even when `modcluster_ha_enabled` is False.

Fix #56
Fix #59 