### PR TITLE
Allow to configure TCPPING for discovery

### DIFF
--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -50,6 +50,7 @@ Role Defaults
 | Variable | Description | Default |
 |:---------|:------------|:---------|
 |`keycloak_ha_enabled`| Enable auto configuration for database backend, clustering and remote caches on infinispan | `False` |
+|`keycloak_ha_discovery`| Discovery protocol for HA cluster members | `JDBC_PING` if keycloak_db_enabled else `TCPPING` |
 |`keycloak_db_enabled`| Enable auto configuration for database backend | `True` if `keycloak_ha_enabled` is True, else `False` |
 |`keycloak_admin_user`| Administration console user account | `admin` |
 |`keycloak_bind_address`| Address for binding service ports | `0.0.0.0` |

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -46,6 +46,8 @@ keycloak_prefer_ipv4: True
 keycloak_ha_enabled: False
 ### Enable database configuration, must be enabled when HA is configured
 keycloak_db_enabled: "{{ True if keycloak_ha_enabled else False }}"
+### Discovery protocol for ha cluster members, valus [ 'JDBC_PING', 'TCPPING' ]
+keycloak_ha_discovery: "{{ 'JDBC_PING' if keycloak_db_enabled else 'TCPPING' }}"
 
 ### Keycloak administration console user
 keycloak_admin_user: admin

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -148,6 +148,10 @@ argument_specs:
                 default: false
                 description: "Enable auto configuration for database backend, clustering and remote caches on infinispan"
                 type: "bool"
+            keycloak_ha_discovery:
+                default: "{{ 'JDBC_PING' if keycloak_db_enabled else 'TCPPING' }}"
+                description: "Discovery protocol for HA cluster members"
+                type: "str"
             keycloak_db_enabled:
                 # line 48 of keycloak/defaults/main.yml
                 default: "{{ True if keycloak_ha_enabled else False }}"

--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -187,6 +187,19 @@
     - restart keycloak
   when: not keycloak_remotecache.enabled or keycloak_config_override_template | length > 0
 
+- name: Create cluster node list
+  ansible.builtin.set_fact:
+    keycloak_cluster_nodes: >
+      {{ keycloak_cluster_nodes | default([]) + [
+        {
+          "name": item,
+          "address": 'jgroups-' + item,
+          "inventory_host": hostvars[item].ansible_default_ipv4.address | default(item) + '[' + keycloak_jgroups_port + ']',
+          "value": hostvars[item].ansible_default_ipv4.address | default(item)
+        }
+      ] }}
+     loop: "{{ ansible_play_batch }}"
+
 - name: "Deploy {{ keycloak.service_name }} config with remote cache store to {{ keycloak_config_path_to_standalone_xml }}"
   become: yes
   ansible.builtin.template:

--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -198,7 +198,7 @@
           "value": hostvars[item].ansible_default_ipv4.address | default(item)
         }
       ] }}
-     loop: "{{ ansible_play_batch }}"
+    loop: "{{ ansible_play_batch }}"
 
 - name: "Deploy {{ keycloak.service_name }} config with remote cache store to {{ keycloak_config_path_to_standalone_xml }}"
   become: yes

--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -187,7 +187,7 @@
     - restart keycloak
   when: not keycloak_remotecache.enabled or keycloak_config_override_template | length > 0
 
-- name: Create cluster node list
+- name: Create tcpping cluster node list
   ansible.builtin.set_fact:
     keycloak_cluster_nodes: >
       {{ keycloak_cluster_nodes | default([]) + [
@@ -199,6 +199,7 @@
         }
       ] }}
     loop: "{{ ansible_play_batch }}"
+  when: keycloak_ha_enabled and keycloak_ha_discovery == 'TCPPING'
 
 - name: "Deploy {{ keycloak.service_name }} config with remote cache store to {{ keycloak_config_path_to_standalone_xml }}"
   become: yes

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -488,13 +488,20 @@
             <stacks>
                 <stack name="tcp">
                     <transport site="${jboss.node.name}" type="TCP" socket-binding="jgroups-tcp"/>
-{% if keycloak_jdbc[keycloak_jdbc_engine].enabled %}
+{% if keycloak_ha_discovery == 'JDBC_PING' and keycloak_jdbc[keycloak_jdbc_engine].enabled %}
                     <protocol type="JDBC_PING">
                         <property name="datasource_jndi_name">java:jboss/datasources/KeycloakDS</property>
                         <property name="initialize_sql">{{ keycloak_jdbc[keycloak_jdbc_engine].initialize_db }}</property>
                         <property name="insert_single_sql">INSERT INTO JGROUPSPING (own_addr, cluster_name, ping_data) values (?, ?, ?)</property>
                         <property name="delete_single_sql">DELETE FROM JGROUPSPING WHERE own_addr=? AND cluster_name=?</property>
                         <property name="select_all_pingdata_sql">SELECT ping_data FROM JGROUPSPING WHERE cluster_name=?</property>
+                    </protocol>
+{% elif keycloak_ha_discovery == 'TCPPING' %}
+                    <protocol type="TCPPING">
+                        <property name="initial_hosts">{{ keycloak_cluster_nodes | map(attribute='inventory_host') | join (',') }}</property>
+                        <property name="port_range">0</property>
+                        <property name="timeout">3000</property>
+                        <property name="num_initial_members">2</property>
                     </protocol>
 {% endif %}
                     <protocol type="MERGE3"/>
@@ -708,6 +715,13 @@
 {% for modcluster in keycloak_modcluster.reverse_proxy_urls %}
         <outbound-socket-binding name="proxy_{{ modcluster.host }}">
             <remote-destination host="{{ modcluster.host }}" port="{{ modcluster.port }}"/>
+        </outbound-socket-binding>
+{% endfor %}
+{% endif %}
+{% if keycloak_ha_discovery == 'TCPPING' %}
+{% for node in keycloak_cluster_nodes %}
+        <outbound-socket-binding name="jgroups_{{ node.address }}">
+            <remote-destination host="{{ node.value }}" port="{{ keycloak_jgroups_port }}"/>
         </outbound-socket-binding>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
When `keycloak_ha_enabled` (and `keycloak_db_enabled` also is in that case), the cluster discover protocol defaults to `JDBC_PING`. A new variable allows to set `TCPPING` as the discovery protocol instead, using the ansible play batch nodes as initial_nodes.

| Variable | Description | Default |
|:---------|:------------|:---------|
|`keycloak_ha_discovery`| Discovery protocol for HA cluster members | `JDBC_PING` if keycloak_db_enabled else `TCPPING` |


Fix #58