### PR TITLE
Close #74 - add `sqlserver` support to keycloak role

### DIFF
--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -83,7 +83,7 @@ Role Defaults
 | Variable | Description | Default |
 |:---------|:------------|:---------|
 |`keycloak_offline_install` | perform an offline install | `False`|
-|`keycloak_download_url`| Download URL for keycloak | `https://github.com/keycloak/keycloak/releases/download/<version>/<archive>`| 
+|`keycloak_download_url`| Download URL for keycloak | `https://github.com/keycloak/keycloak/releases/download/<version>/<archive>`|
 |`keycloak_version`| keycloak.org package version | `18.0.2` |
 |`keycloak_dest`| Installation root path | `/opt/keycloak` |
 |`keycloak_download_url` | Download URL for keycloak | `https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/{{ keycloak_archive }}` |
@@ -127,7 +127,7 @@ The following variables are _required_ only when `keycloak_ha_enabled` is True:
 |`keycloak_modcluster_url` | _deprecated_ Host for the modcluster reverse proxy | `localhost` |
 |`keycloak_modcluster_port` | _deprecated_ Port for the modcluster reverse proxy | `6666` |
 |`keycloak_modcluster_urls` | List of {host,port} dicts for the modcluster reverse proxies | `[ { localhost:6666 } ]` |
-|`keycloak_jdbc_engine` | backend database engine when db is enabled: [ postgres, mariadb ] | `postgres` |
+|`keycloak_jdbc_engine` | backend database engine when db is enabled: [ postgres, mariadb, sqlserver ] | `postgres` |
 |`keycloak_infinispan_url` | URL for the infinispan remote-cache server | `localhost:11122` |
 |`keycloak_infinispan_user` | username for connecting to infinispan | `supervisor` |
 |`keycloak_infinispan_pass` | password for connecting to infinispan | `supervisor` |

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -79,7 +79,7 @@ keycloak_infinispan_use_ssl: False
 keycloak_infinispan_trust_store_path: /etc/pki/java/cacerts
 keycloak_infinispan_trust_store_password: changeit
 
-### database backend engine: values [ 'postgres', 'mariadb' ]
+### database backend engine: values [ 'postgres', 'mariadb', 'sqlserver' ]
 keycloak_jdbc_engine: postgres
 ### database backend credentials
 keycloak_db_user: keycloak-user
@@ -94,5 +94,8 @@ keycloak_default_jdbc:
   mariadb:
     url: 'jdbc:mariadb://localhost:3306/keycloak'
     version: 2.7.4
+  sqlserver:
+    url: 'jdbc:sqlserver://localhost:1433;databaseName=keycloak;'
+    version: 12.2.0
 # role specific vars
 keycloak_no_log: True

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -237,7 +237,7 @@ argument_specs:
             keycloak_jdbc_engine:
                 # line 72 of keycloak/defaults/main.yml
                 default: "postgres"
-                description: "Backend database flavour when db is enabled: [ postgres, mariadb ]"
+                description: "Backend database flavour when db is enabled: [ postgres, mariadb, sqlserver ]"
                 type: "str"
             keycloak_db_user:
                 # line 74 of keycloak/defaults/main.yml

--- a/roles/keycloak/tasks/prereqs.yml
+++ b/roles/keycloak/tasks/prereqs.yml
@@ -27,7 +27,7 @@
 - name: Validate persistence configuration
   ansible.builtin.assert:
     that:
-      - keycloak_jdbc_engine is defined and keycloak_jdbc_engine in [ 'postgres', 'mariadb' ]
+      - keycloak_jdbc_engine is defined and keycloak_jdbc_engine in [ 'postgres', 'mariadb', 'sqlserver' ]
       - keycloak_jdbc_url | length > 0
       - keycloak_db_user | length > 0
       - keycloak_db_pass | length > 0

--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -56,6 +56,28 @@ keycloak_jdbc:
         ping_data varbinary(5000) DEFAULT NULL,
         PRIMARY KEY (own_addr, cluster_name))
       ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+  sqlserver:
+    enabled: "{{ (keycloak_ha_enabled or keycloak_db_enabled) and keycloak_jdbc_engine == 'sqlserver' }}"
+    driver_class: com.microsoft.sqlserver.jdbc.SQLServerDriver
+    xa_datasource_class: com.microsoft.sqlserver.jdbc.SQLServerXADataSource
+    driver_module_name: "com.microsoft.sqlserver"
+    driver_module_dir: "{{ keycloak_jboss_home }}/modules/com/microsoft/sqlserver/main"
+    driver_version: "{{ keycloak_jdbc_driver_version }}"
+    driver_jar_filename: "mssql-java-client-{{ keycloak_jdbc_driver_version }}.jar"
+    driver_jar_url: "https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/{{ keycloak_jdbc_driver_version }}.jre11/mssql-jdbc-{{ keycloak_jdbc_driver_version }}.jre11.jar" # e.g., https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.2.0.jre11/mssql-jdbc-12.2.0.jre11.jar
+    connection_url: "{{ keycloak_jdbc_url }}"
+    db_user: "{{ keycloak_db_user }}"
+    db_password: "{{ keycloak_db_pass }}"
+    initialize_db: >
+      IF  NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[JGROUPSPING]') AND type in (N'U'))
+      BEGIN
+        CREATE TABLE JGROUPSPING (
+          own_addr varchar(200) NOT NULL,
+          cluster_name varchar(200) NOT NULL,
+          updated DATETIME2 DEFAULT SYSUTCDATETIME(),
+          ping_data varbinary(5000) DEFAULT NULL,
+          PRIMARY KEY (own_addr, cluster_name))
+      END
 
 # reverse proxy mod_cluster
 keycloak_modcluster:


### PR DESCRIPTION
Tested locally inside a docker container and a "real" SQL server
