### PR TITLE
Introduce systemd unit restart behavior

### DIFF
--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -72,6 +72,10 @@ Role Defaults
 |`keycloak_config_standalone_xml`| filename for configuration | `keycloak.xml` |
 |`keycloak_service_user`| posix account username | `keycloak` |
 |`keycloak_service_group`| posix account group | `keycloak` |
+|`keycloak_service_restart_on_failure`| systemd restart-on-failure behavior activation |True
+|`keycloak_service_startlimitintervalsec`| systemd StartLimitIntervalSec | `300` if `keycloak_service_restart_on_failure` else ``
+|`keycloak_service_startlimitburst`| systemd StartLimitBurst | `5` if `keycloak_service_restart_on_failure` else ``
+|`keycloak_service_restartsec`| systemd RestartSec | `10s` if `keycloak_service_restart_on_failure` else ``
 |`keycloak_service_pidfile`| pid file path for service | `/run/keycloak.pid` |
 |`keycloak_jvm_package`| RHEL java package runtime | `java-1.8.0-openjdk-headless` |
 |`keycloak_java_home`| JAVA_HOME of installed JRE, leave empty for using specified keycloak_jvm_package RPM path | `None` |
@@ -116,7 +120,7 @@ The following are a set of _required_ variables for the role:
 | Variable | Description |
 |:---------|:------------|
 |`keycloak_admin_password`| Password for the administration console user account (minimum 12 characters) |
-|`keycloak_frontend_url` | frontend URL for keycloak endpoint | `http://localhost:8080/auth` |
+|`keycloak_frontend_url` | frontend URL for keycloak endpoint | `http://localhost:8080/auth/` |
 
 
 The following variables are _required_ only when `keycloak_ha_enabled` is True:

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -23,6 +23,10 @@ keycloak_service_name: keycloak
 keycloak_service_desc: Keycloak
 keycloak_service_start_delay: 10
 keycloak_service_start_retries: 25
+keycloak_service_restart_on_failure: True
+keycloak_service_startlimitintervalsec: "{{ 300 if keycloak_service_restart_on_failure else '' }}"
+keycloak_service_startlimitburst: "{{ 5 if keycloak_service_restart_on_failure else '' }}"
+keycloak_service_restartsec: "{{ '10s' if keycloak_service_restart_on_failure else '' }}"
 
 keycloak_configure_firewalld: False
 
@@ -67,7 +71,7 @@ keycloak_modcluster_urls:
     port: "{{ keycloak_modcluster_port }}"
 
 ### keycloak frontend url
-keycloak_frontend_url: http://localhost:8080/auth
+keycloak_frontend_url: http://localhost:8080/auth/
 
 ### infinispan remote caches access (hotrod)
 keycloak_infinispan_user: supervisor

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -290,6 +290,22 @@ argument_specs:
                 default: "25"
                 description: "How many time should Ansible retry to connect to the service after it was started, before failing."
                 type: "int"
+            keycloak_service_restart_on_failure:
+                default: true
+                description: "systemd restart-on-failure behavior activation for keycloak"
+                type: "bool"
+            keycloak_service_startlimitintervalsec:
+                default: 300
+                description: "systemd StartLimitIntervalSec for keycloak"
+                type: "int"
+            keycloak_service_startlimitburst:
+                default: 5
+                description: "systemd StartLimitBurst for keycloak"
+                type: "int"
+            keycloak_service_restartsec:
+                default: "5s"
+                description: "systemd RestartSec for keycloak"
+                type: "str"
             keycloak_no_log:
                 default: true
                 type: "bool"

--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -266,5 +266,5 @@
     - restart keycloak
   when:
     - keycloak_ha_enabled
-    - keycloak_remote_cache_enabled    
+    - keycloak_remote_cache_enabled
     - keycloak_config_override_template | length == 0

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -2,6 +2,11 @@
 [Unit]
 Description={{ keycloak.service_name }} Server
 After=network.target
+{% if keycloak_service_restart_on_failure %}
+StartLimitIntervalSec={{ keycloak_service_startlimitintervalsec }}
+StartLimitBurst={{ keycloak_service_startlimitburst }}
+{% endif %}
+
 
 [Service]
 Type=forking
@@ -12,6 +17,10 @@ ExecStop={{ keycloak_dest }}/keycloak-service.sh stop
 TimeoutStartSec=30
 TimeoutStopSec=30
 LimitNOFILE=102642
+{% if keycloak_service_restart_on_failure %}
+Restart=on-failure
+RestartSec={{ keycloak_service_restartsec }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Introduce a flag variable that allows to setup systemd restart behaviour, and additional variables to fine-tune it:


| Variable | Description | Default |
|:---------|:------------|:---------|
|`keycloak_service_restart_on_failure`| systemd restart-on-failure behavior activation |True
|`keycloak_service_startlimitintervalsec`| systemd StartLimitIntervalSec | `300` if `keycloak_service_restart_on_failure` else ``
|`keycloak_service_startlimitburst`| systemd StartLimitBurst | `5` if `keycloak_service_restart_on_failure` else ``
|`keycloak_service_restartsec`| systemd RestartSec | `10s` if `keycloak_service_restart_on_failure` else ``

Fix #80