### PR TITLE
Add configuration for database connection pool validation

### DIFF
--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -111,6 +111,11 @@ Role Defaults
 |`keycloak_url` | URL for configuration rest calls | `http://{{ keycloak_host }}:{{ keycloak_http_port }}` |
 |`keycloak_management_url` | URL for management console rest calls | `http://{{ keycloak_host }}:{{ keycloak_management_http_port }}` |
 |`keycloak_frontend_url_force` | Force backend requests to use the frontend URL | `False` |
+|`keycloak_db_background_validation` | Enable background validation of database connection | `False` |
+|`keycloak_db_background_validation_millis`| How frequenly the connection pool is validated in the background | `10000` if background validation enabled |
+|`keycloak_db_background_validate_on_match` Enable validate on match for database connections | `False` |
+|`keycloak_frontend_url` | frontend URL for keycloak endpoint | `http://localhost:8080/auth/` |
+
 
 Role Variables
 --------------
@@ -123,7 +128,7 @@ The following are a set of _required_ variables for the role:
 |`keycloak_frontend_url` | frontend URL for keycloak endpoint | `http://localhost:8080/auth/` |
 
 
-The following variables are _required_ only when `keycloak_ha_enabled` is True:
+The following parameters are _required_ only when `keycloak_ha_enabled` is True:
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
@@ -141,7 +146,7 @@ The following variables are _required_ only when `keycloak_ha_enabled` is True:
 |`keycloak_infinispan_trust_store_password`| Password for opening truststore | `changeit` |
 
 
-The following variables are _required_ only when `keycloak_db_enabled` is True:
+The following parameters are _required_ only when `keycloak_db_enabled` is True:
 
 | Variable | Description | Default |
 |:---------|:------------|:---------|
@@ -149,6 +154,13 @@ The following variables are _required_ only when `keycloak_db_enabled` is True:
 |`keycloak_jdbc_driver_version`| Version for the JDBC driver to download | `9.4.1212` |
 |`keycloak_db_user` | username for connecting to postgres | `keycloak-user` |
 |`keycloak_db_pass` | password for connecting to postgres | `keycloak-pass` |
+
+
+The following variables are _optional_:
+
+| Variable | Description |
+|:---------|:------------|
+|`keycloak_db_valid_conn_sql` | Override the default database connection validation query sql |
 
 
 Example Playbook
@@ -161,8 +173,6 @@ Example Playbook
 - hosts: ...
       vars:
         keycloak_admin_password: "remembertochangeme"
-      collections:
-        - middleware_automation.keycloak
       roles:
         - middleware_automation.keycloak.keycloak
 ```

--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -113,7 +113,7 @@ Role Defaults
 |`keycloak_frontend_url_force` | Force backend requests to use the frontend URL | `False` |
 |`keycloak_db_background_validation` | Enable background validation of database connection | `False` |
 |`keycloak_db_background_validation_millis`| How frequenly the connection pool is validated in the background | `10000` if background validation enabled |
-|`keycloak_db_background_validate_on_match` Enable validate on match for database connections | `False` |
+|`keycloak_db_background_validate_on_match` | Enable validate on match for database connections | `False` |
 |`keycloak_frontend_url` | frontend URL for keycloak endpoint | `http://localhost:8080/auth/` |
 
 

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -89,6 +89,12 @@ keycloak_jdbc_engine: postgres
 ### database backend credentials
 keycloak_db_user: keycloak-user
 keycloak_db_pass: keycloak-pass
+## connection validation
+keycloak_db_background_validation: False
+keycloak_db_background_validation_millis: "{{ 10000 if keycloak_db_background_validation else 0 }}"
+keycloak_db_background_validate_on_match: False
+# variable to override database connection validation query
+keycloak_db_valid_conn_sql:
 keycloak_jdbc_url: "{{ keycloak_default_jdbc[keycloak_jdbc_engine].url }}"
 keycloak_jdbc_driver_version: "{{ keycloak_default_jdbc[keycloak_jdbc_engine].version }}"
 # override the variables above, following defaults show minimum supported versions

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -318,6 +318,22 @@ argument_specs:
                 default: "{{ True if keycloak_ha_enabled else False }}"
                 description: "Enable remote cache store when in clustered ha configurations"
                 type: "bool"
+            keycloak_db_background_validation: 
+                default: False
+                description: "Enable background validation of database connection"
+                type: "bool"
+            keycloak_db_background_validation_millis:
+                default: "{{ 10000 if keycloak_db_background_validation else 0 }}"
+                description: "How frequenly the connection pool is validated in the background"
+                type: 'int'
+            keycloak_db_background_validate_on_match:
+                default: False
+                description: "Enable validate on match for database connections"
+                type: "bool"
+            keycloak_db_valid_conn_sql:
+                required: False
+                description: "Override the default database connection validation query sql"
+                type: "str"
     downstream:
         options:
             sso_version:

--- a/roles/keycloak/templates/standalone-ha.xml.j2
+++ b/roles/keycloak/templates/standalone-ha.xml.j2
@@ -136,6 +136,12 @@
                         <user-name>{{ keycloak_jdbc[keycloak_jdbc_engine].db_user }}</user-name>
                         <password>{{ keycloak_jdbc[keycloak_jdbc_engine].db_password }}</password>
                     </security>
+                    <validation>
+                        <check-valid-connection-sql>{{ keycloak_jdbc[keycloak_jdbc_engine].validate_query }}</check-valid-connection-sql>
+                        <validate-on-match>{{ keycloak_db_background_validate_on_match }}</validate-on-match>
+                        <background-validation>{{ keycloak_db_background_validation }}</background-validation>
+                        <background-validation-millis>{{ keycloak_db_background_validation_millis }}</background-validation-millis>
+                    </validation>
 {% else %}
                     <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
                     <driver>h2</driver>

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -136,6 +136,12 @@
                         <user-name>{{ keycloak_jdbc[keycloak_jdbc_engine].db_user }}</user-name>
                         <password>{{ keycloak_jdbc[keycloak_jdbc_engine].db_password }}</password>
                     </security>
+                    <validation>
+                        <check-valid-connection-sql>{{ keycloak_jdbc[keycloak_jdbc_engine].validate_query }}</check-valid-connection-sql>
+                        <validate-on-match>{{ keycloak_db_background_validate_on_match }}</validate-on-match>
+                        <background-validation>{{ keycloak_db_background_validation }}</background-validation>
+                        <background-validation-millis>{{ keycloak_db_background_validation_millis }}</background-validation-millis>
+                    </validation>
 {% else %}
                     <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
                     <driver>h2</driver>

--- a/roles/keycloak/templates/standalone.xml.j2
+++ b/roles/keycloak/templates/standalone.xml.j2
@@ -123,6 +123,12 @@
                         <user-name>{{ keycloak_jdbc[keycloak_jdbc_engine].db_user }}</user-name>
                         <password>{{ keycloak_jdbc[keycloak_jdbc_engine].db_password }}</password>
                     </security>
+                    <validation>
+                        <check-valid-connection-sql>{{ keycloak_jdbc[keycloak_jdbc_engine].validate_query }}</check-valid-connection-sql>
+                        <validate-on-match>{{ keycloak_db_background_validate_on_match }}</validate-on-match>
+                        <background-validation>{{ keycloak_db_background_validation }}</background-validation>
+                        <background-validation-millis>{{ keycloak_db_background_validation_millis }}</background-validation-millis>
+                    </validation>
 {% else %}
                     <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
                     <driver>h2</driver>

--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -29,6 +29,7 @@ keycloak_jdbc:
     connection_url: "{{ keycloak_jdbc_url }}"
     db_user: "{{ keycloak_db_user }}"
     db_password: "{{ keycloak_db_pass }}"
+    validate_query: "{{ keycloak_db_valid_conn_sql | default('select 1') }}"
     initialize_db: >
       CREATE TABLE IF NOT EXISTS JGROUPSPING (
         own_addr varchar(200) NOT NULL,
@@ -48,6 +49,7 @@ keycloak_jdbc:
     connection_url: "{{ keycloak_jdbc_url }}"
     db_user: "{{ keycloak_db_user }}"
     db_password: "{{ keycloak_db_pass }}"
+    validate_query: "{{ keycloak_db_valid_conn_sql | default('select 1') }}"
     initialize_db: >
       CREATE TABLE IF NOT EXISTS JGROUPSPING (
         own_addr varchar(200) NOT NULL,
@@ -68,6 +70,7 @@ keycloak_jdbc:
     connection_url: "{{ keycloak_jdbc_url }}"
     db_user: "{{ keycloak_db_user }}"
     db_password: "{{ keycloak_db_pass }}"
+    validate_query: "{{ keycloak_db_valid_conn_sql | default('select 1') }}"
     initialize_db: >
       IF  NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[JGROUPSPING]') AND type in (N'U'))
       BEGIN


### PR DESCRIPTION
It is now possible to set the behaviour for database connection validation using the following parameters:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_db_background_validation` | Enable background validation of database connection | `False` |
|`keycloak_db_background_validation_millis`| How frequenly the connection pool is validated in the background | `10000` if background validation enabled |
|`keycloak_db_background_validate_on_match` | Enable validate on match for database connections | `False` |

Note that the keycloak setting configured with keycloak_db_background_validation is deprecated; also, having keycloak_db_background_validation set to false, and a non-zero keycloak_db_background_validation_millis will produce an incorrect configuration.


The default sql query used to validate the connection can be overridden defining the variable:

| Variable | Description |
|:---------|:------------|
|`keycloak_db_valid_conn_sql` | Override the default database connection validation query sql |

Fix #82 