### PR TITLE
Allow to configure administration endpoint URL

### DIFF
--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -117,6 +117,7 @@ Role Defaults
 |`keycloak_frontend_url` | frontend URL for keycloak endpoint | `http://localhost:8080/auth/` |
 
 
+
 Role Variables
 --------------
 
@@ -161,6 +162,7 @@ The following variables are _optional_:
 | Variable | Description |
 |:---------|:------------|
 |`keycloak_db_valid_conn_sql` | Override the default database connection validation query sql |
+|`keycloak_admin_url` | Override the default administration endpoint URL |
 
 
 Example Playbook

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -73,6 +73,7 @@ keycloak_modcluster_urls:
 ### keycloak frontend url
 keycloak_frontend_url: http://localhost:8080/auth/
 keycloak_frontend_url_force: False
+keycloak_admin_url:
 
 ### infinispan remote caches access (hotrod)
 keycloak_infinispan_user: supervisor

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -334,6 +334,10 @@ argument_specs:
                 required: False
                 description: "Override the default database connection validation query sql"
                 type: "str"
+            keycloak_admin_url:
+                required: False
+                description: "Override the default administration endpoint URL"
+                type: "str"
     downstream:
         options:
             sso_version:

--- a/roles/keycloak/templates/standalone-ha.xml.j2
+++ b/roles/keycloak/templates/standalone-ha.xml.j2
@@ -580,6 +580,9 @@
                     <properties>
                         <property name="frontendUrl" value="{{ keycloak_modcluster.frontend_url }}"/>
                         <property name="forceBackendUrlToFrontendUrl" value="{{ keycloak_modcluster.force_frontend_url }}"/>
+{% if keycloak_modcluster.admin_url | length > 0 %}
+                        <property name="adminUrl" value="{{ keycloak_modcluster.admin_url }}" />
+{% endif %}
                     </properties>
                 </provider>
             </spi>

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -618,6 +618,9 @@
                     <properties>
                         <property name="frontendUrl" value="{{ keycloak_modcluster.frontend_url }}"/>
                         <property name="forceBackendUrlToFrontendUrl" value="{{ keycloak_modcluster.force_frontend_url }}"/>
+{% if keycloak_modcluster.admin_url | length > 0 %}
+                        <property name="adminUrl" value="{{ keycloak_modcluster.admin_url }}" />
+{% endif %}
                     </properties>
                 </provider>
             </spi>

--- a/roles/keycloak/templates/standalone.xml.j2
+++ b/roles/keycloak/templates/standalone.xml.j2
@@ -524,6 +524,9 @@
                     <properties>
                         <property name="frontendUrl" value="{{ keycloak_modcluster.frontend_url }}"/>
                         <property name="forceBackendUrlToFrontendUrl" value="{{ keycloak_modcluster.force_frontend_url }}"/>
+{% if keycloak_modcluster.admin_url | length > 0 %}
+                        <property name="adminUrl" value="{{ keycloak_modcluster.admin_url }}" />
+{% endif %}
                     </properties>
                 </provider>
             </spi>

--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -88,6 +88,7 @@ keycloak_modcluster:
   reverse_proxy_urls: "{{ keycloak_modcluster_urls }}"
   frontend_url: "{{ keycloak_frontend_url }}"
   force_frontend_url: "{{ keycloak_frontend_url_force }}"
+  admin_url: "{{ keycloak_admin_url | default('') }}"
 
 # infinispan
 keycloak_remotecache:


### PR DESCRIPTION
New variable (default undefined) allows to override the URL for the administration endpoint:

| Variable | Description |
|:---------|:------------|
|`keycloak_admin_url` | Override the default administration endpoint URL |

Beware: setting `keycloak_admin_url` will require updating the configuration for the `keycloak_realm` role which consumes the API at the default endpoint.

Fix #83 