### PR TITLE
Improve service restart behavior configuration

### DIFF
--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -72,10 +72,11 @@ Role Defaults
 |`keycloak_config_standalone_xml`| filename for configuration | `keycloak.xml` |
 |`keycloak_service_user`| posix account username | `keycloak` |
 |`keycloak_service_group`| posix account group | `keycloak` |
-|`keycloak_service_restart_on_failure`| systemd restart-on-failure behavior activation |True
-|`keycloak_service_startlimitintervalsec`| systemd StartLimitIntervalSec | `300` if `keycloak_service_restart_on_failure` else `` |
-|`keycloak_service_startlimitburst`| systemd StartLimitBurst | `5` if `keycloak_service_restart_on_failure` else `` |
-|`keycloak_service_restartsec`| systemd RestartSec | `10s` if `keycloak_service_restart_on_failure` else `` |
+|`keycloak_service_restart_always`| systemd restart always behavior activation | `False`
+|`keycloak_service_restart_on_failure`| systemd restart on-failure behavior activation | `False`
+|`keycloak_service_startlimitintervalsec`| systemd StartLimitIntervalSec | `300` |
+|`keycloak_service_startlimitburst`| systemd StartLimitBurst | `5` |
+|`keycloak_service_restartsec`| systemd RestartSec | `10s` |
 |`keycloak_service_pidfile`| pid file path for service | `/run/keycloak.pid` |
 |`keycloak_features` | List of `name`/`status` pairs of features (also known as profiles on RH-SSO) to `enable` or `disable`, example: `[ { name: 'docker', status: 'enabled' } ]` | `[]`
 |`keycloak_jvm_package`| RHEL java package runtime | `java-1.8.0-openjdk-headless` |

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -24,10 +24,11 @@ keycloak_service_name: keycloak
 keycloak_service_desc: Keycloak
 keycloak_service_start_delay: 10
 keycloak_service_start_retries: 25
-keycloak_service_restart_on_failure: True
-keycloak_service_startlimitintervalsec: "{{ 300 if keycloak_service_restart_on_failure else '' }}"
-keycloak_service_startlimitburst: "{{ 5 if keycloak_service_restart_on_failure else '' }}"
-keycloak_service_restartsec: "{{ '10s' if keycloak_service_restart_on_failure else '' }}"
+keycloak_service_restart_always: False
+keycloak_service_restart_on_failure: False
+keycloak_service_startlimitintervalsec: "300"
+keycloak_service_startlimitburst: "5"
+keycloak_service_restartsec: "10s"
 
 keycloak_configure_firewalld: False
 

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -299,9 +299,13 @@ argument_specs:
                 default: "25"
                 description: "How many time should Ansible retry to connect to the service after it was started, before failing."
                 type: "int"
+            keycloak_service_restart_always:
+                default: false
+                description: "systemd restart always behavior activation for keycloak"
+                type: "bool"
             keycloak_service_restart_on_failure:
-                default: true
-                description: "systemd restart-on-failure behavior activation for keycloak"
+                default: false
+                description: "systemd restart on-failure behavior activation for keycloak"
                 type: "bool"
             keycloak_service_startlimitintervalsec:
                 default: 300

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -2,10 +2,8 @@
 [Unit]
 Description={{ keycloak.service_name }} Server
 After=network.target
-{% if keycloak_service_restart_on_failure %}
 StartLimitIntervalSec={{ keycloak_service_startlimitintervalsec }}
 StartLimitBurst={{ keycloak_service_startlimitburst }}
-{% endif %}
 
 
 [Service]
@@ -17,10 +15,12 @@ ExecStop={{ keycloak_dest }}/keycloak-service.sh stop
 TimeoutStartSec=30
 TimeoutStopSec=30
 LimitNOFILE=102642
-{% if keycloak_service_restart_on_failure %}
+{% if keycloak_service_restart_always %}
+Restart=always
+{% elif keycloak_service_restart_on_failure %}
 Restart=on-failure
-RestartSec={{ keycloak_service_restartsec }}
 {% endif %}
+RestartSec={{ keycloak_service_restartsec }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
... by allowing the user to freely choose from all [available values supported by systemd](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=):

* `no`
* `always`
* `on-success`
* `on-failure`
* `on-abnormal`
* `on-abort`
* `on-watchdog`