### PR TITLE
Change xa_datasource_class value for mariadb jdbc configuration

### DIFF
--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -40,7 +40,7 @@ keycloak_jdbc:
   mariadb:
     enabled: "{{ (keycloak_ha_enabled or keycloak_db_enabled) and keycloak_jdbc_engine == 'mariadb' }}"
     driver_class: org.mariadb.jdbc.Driver
-    xa_datasource_class: org.mariadb.jdbc.MySQLDataSource
+    xa_datasource_class: org.mariadb.jdbc.MariaDbDataSource
     driver_module_name: "org.mariadb"
     driver_module_dir: "{{ keycloak_jboss_home }}/modules/org/mariadb/main"
     driver_version: "{{ keycloak_jdbc_driver_version }}"


### PR DESCRIPTION
`org.mariadb.jdbc.MySQLDataSource` is [deprecated since driver version 1.3.1](https://javadoc.io/doc/org.mariadb.jdbc/mariadb-java-client/1.3.1/org/mariadb/jdbc/MySQLDataSource.html) and has been removed on 3.x.

Since the introduction of `org.mariadb.jdbc.MariaDbDataSource`, `org.mariadb.jdbc.MySQLDataSource` has always been just an alias.

A better value for this key should be `org.mariadb.jdbc.MariaDbDataSource`.
