### PR TITLE
Undefine `keycloak_db_valid_conn_sql` default

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -97,8 +97,6 @@ keycloak_db_pass: keycloak-pass
 keycloak_db_background_validation: False
 keycloak_db_background_validation_millis: "{{ 10000 if keycloak_db_background_validation else 0 }}"
 keycloak_db_background_validate_on_match: False
-# variable to override database connection validation query
-keycloak_db_valid_conn_sql:
 keycloak_jdbc_url: "{{ keycloak_default_jdbc[keycloak_jdbc_engine].url }}"
 keycloak_jdbc_driver_version: "{{ keycloak_default_jdbc[keycloak_jdbc_engine].version }}"
 # override the variables above, following defaults show minimum supported versions


### PR DESCRIPTION
Setting an empty string default for `keycloak_db_valid_conn_sql` results in an empty value in the configuration file. We should rely on defaults set fo `keycloak_jdbc.[database].validate_query`.

The alternative cloud be using `"{{ keycloak_db_valid_conn_sql | default('select 1', true) }}"` value for `keycloak_jdbc.[database].validate_query` 