### PR TITLE
Allow to override jgroups subnet

### DIFF
--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -165,7 +165,7 @@ The following variables are _optional_:
 |:---------|:------------|
 |`keycloak_db_valid_conn_sql` | Override the default database connection validation query sql |
 |`keycloak_admin_url` | Override the default administration endpoint URL |
-
+|`keycloak_jgroups_subnet`| Override the subnet match for jgroups cluster formation; if not defined, it will be inferred from local machine route configuration |
 
 Example Playbook
 -----------------

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -42,6 +42,7 @@ keycloak_http_port: 8080
 keycloak_https_port: 8443
 keycloak_ajp_port: 8009
 keycloak_jgroups_port: 7600
+keycloak_jgroups_subnet:
 keycloak_management_port_bind_address: 127.0.0.1
 keycloak_management_http_port: 9990
 keycloak_management_https_port: 9993

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -347,6 +347,10 @@ argument_specs:
                 required: False
                 description: "Override the default administration endpoint URL"
                 type: "str"
+            keycloak_jgroups_subnet:
+                required: False
+                description: "Override the subnet match for jgroups cluster formation; if not defined, it will be inferred from local machine route configuration"
+                type: "str"
     downstream:
         options:
             sso_version:

--- a/roles/keycloak/templates/standalone-ha.xml.j2
+++ b/roles/keycloak/templates/standalone-ha.xml.j2
@@ -662,7 +662,9 @@
             <inet-address value="{{ keycloak_management_port_bind_address }}"/>
         </interface>
         <interface name="jgroups">
-{% if ansible_default_ipv4 is defined %}
+{% keycloak_jgroups_subnet is defined and keycloak_jgroups_subnet | length > 0 %}
+            <subnet-match value="{{ keycloak_jgroups_subnet }}"/>
+{% elif ansible_default_ipv4 is defined and (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') | length > 0 %}
             <subnet-match value="{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"/>
 {% else %}
             <any-address />

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -700,7 +700,9 @@
             <inet-address value="{{ keycloak_management_port_bind_address }}"/>
         </interface>
         <interface name="jgroups">
-{% if ansible_default_ipv4 is defined %}
+{% keycloak_jgroups_subnet is defined and keycloak_jgroups_subnet | length > 0 %}
+            <subnet-match value="{{ keycloak_jgroups_subnet }}"/>
+{% elif ansible_default_ipv4 is defined and (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') | length > 0 %}
             <subnet-match value="{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"/>
 {% else %}
             <any-address />


### PR DESCRIPTION
New optional variable:

| Variable | Description |
|:---------|:------------|
|`keycloak_jgroups_subnet`| Override the subnet match for jgroups cluster formation; if not defined, it will be inferred from local machine route configuration |

allows to statically override the `<subnet-match value=".."/>` for the `<interface name="jgroups">`.

If left undefined (default), the subnet match is computed as:

    (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net')

The above won't work when instances are isolated (on a a.b.c.d/32 network)