### PR TITLE
Update bindep.txt package python3-devel to support RHEL9

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,4 +1,5 @@
-python39-devel [platform:rpm compile]
+python3-devel [compile platform:rpm]
+python39-devel [compile platform:centos-8 platform:rhel-8]
 git-lfs [platform:rpm]
 python3-netaddr [platform:rpm]
 python3-lxml [platform:rpm]


### PR DESCRIPTION
On RHEL9 the rpm package `python39-devel` doesn't exists. The real name is `python3-devel`.

Based on: https://github.com/ansible-collections/microsoft.ad/blob/main/bindep.txt#L10C59-L10C59

This PR fixes #104