### PR TITLE
Run service as `keycloak_service_user`

### DIFF
--- a/molecule/overridexml/converge.yml
+++ b/molecule/overridexml/converge.yml
@@ -6,6 +6,7 @@
     keycloak_config_override_template: custom.xml.j2
     keycloak_http_port: 8081
     keycloak_management_http_port: 19990
+    keycloak_service_runas: True
   roles:
     - role: keycloak
   tasks:

--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -77,7 +77,7 @@ Role Defaults
 |`keycloak_service_startlimitintervalsec`| systemd StartLimitIntervalSec | `300` |
 |`keycloak_service_startlimitburst`| systemd StartLimitBurst | `5` |
 |`keycloak_service_restartsec`| systemd RestartSec | `10s` |
-|`keycloak_service_pidfile`| pid file path for service | `/run/keycloak.pid` |
+|`keycloak_service_pidfile`| pid file path for service | `/run/keycloak/keycloak.pid` |
 |`keycloak_features` | List of `name`/`status` pairs of features (also known as profiles on RH-SSO) to `enable` or `disable`, example: `[ { name: 'docker', status: 'enabled' } ]` | `[]`
 |`keycloak_jvm_package`| RHEL java package runtime | `java-1.8.0-openjdk-headless` |
 |`keycloak_java_home`| JAVA_HOME of installed JRE, leave empty for using specified keycloak_jvm_package RPM path | `None` |

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -17,6 +17,7 @@ keycloak_config_standalone_xml: "keycloak.xml"
 keycloak_config_path_to_standalone_xml: "{{ keycloak_jboss_home }}/standalone/configuration/{{ keycloak_config_standalone_xml }}"
 keycloak_config_override_template: ''
 keycloak_config_path_to_properties: "{{ keycloak_jboss_home }}/standalone/configuration/profile.properties"
+keycloak_service_runas: false
 keycloak_service_user: keycloak
 keycloak_service_group: keycloak
 keycloak_service_pidfile: "/run/keycloak/keycloak.pid"

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -19,7 +19,7 @@ keycloak_config_override_template: ''
 keycloak_config_path_to_properties: "{{ keycloak_jboss_home }}/standalone/configuration/profile.properties"
 keycloak_service_user: keycloak
 keycloak_service_group: keycloak
-keycloak_service_pidfile: "/run/keycloak.pid"
+keycloak_service_pidfile: "/run/keycloak/keycloak.pid"
 keycloak_service_name: keycloak
 keycloak_service_desc: Keycloak
 keycloak_service_start_delay: 10

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -86,7 +86,7 @@ argument_specs:
                 type: "str"
             keycloak_service_pidfile:
                 # line 31 of keycloak/defaults/main.yml
-                default: "/run/keycloak.pid"
+                default: "/run/keycloak/keycloak.pid"
                 description: "PID file path for service"
                 type: "str"
             keycloak_features:

--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -74,6 +74,11 @@ argument_specs:
                 default: ""
                 description: "Path to custom template for standalone.xml configuration"
                 type: "str"
+            keycloak_service_runas: 
+                # line 20 of keycloak/defaults/main.yml
+                default: false
+                description: "Enable execution of service as `keycloak_service_user`"
+                type: "bool"
             keycloak_service_user:
                 # line 29 of keycloak/defaults/main.yml
                 default: "keycloak"

--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -53,20 +53,14 @@
     group: "{{ keycloak_service_group }}"
     mode: 0750
 
-- name: Check pidfile folder
-  ansible.builtin.stat:
-    path: "{{ keycloak_service_pidfile | dirname }}"
-  register: keycloak_service_pidfile_stat
 - name: Create pidfile folder
   become: yes
-  become_user: root
   ansible.builtin.file:
     dest: "{{ keycloak_service_pidfile | dirname }}"
     state: directory
-    owner: "{{ keycloak_service_user }}"
-    group: "{{ keycloak_service_group }}"
-    mode: "0750"
-  when: not keycloak_service_pidfile_stat.stat.exists
+    owner: "{{ keycloak_service_user if keycloak_service_runas else omit }}"
+    group: "{{ keycloak_service_group if keycloak_service_runas else omit }}"
+    mode: 0750
 
 ## check remote archive
 - name: Set download archive path
@@ -206,6 +200,12 @@
     owner: "{{ keycloak_service_user }}"
     group: "{{ keycloak_service_group }}"
     recurse: true
+  become: yes
+  changed_when: false
+
+- name: Ensure permissions are correct on existing deploy
+  ansible.builtin.command: chown -R "{{ keycloak_service_user }}:{{ keycloak_service_group }}" "{{ keycloak.home }}"
+  when: keycloak_service_runas
   become: yes
   changed_when: false
 

--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -53,6 +53,21 @@
     group: "{{ keycloak_service_group }}"
     mode: 0750
 
+- name: Check pidfile folder
+  ansible.builtin.stat:
+    path: "{{ keycloak_service_pidfile | dirname }}"
+  register: keycloak_service_pidfile_stat
+- name: Create pidfile folder
+  become: yes
+  become_user: root
+  ansible.builtin.file:
+    dest: "{{ keycloak_service_pidfile | dirname }}"
+    state: directory
+    owner: "{{ keycloak_service_user }}"
+    group: "{{ keycloak_service_group }}"
+    mode: "0750"
+  when: not keycloak_service_pidfile_stat.stat.exists
+
 ## check remote archive
 - name: Set download archive path
   ansible.builtin.set_fact:

--- a/roles/keycloak/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak/templates/keycloak-sysconfig.j2
@@ -8,4 +8,12 @@ KEYCLOAK_HTTPS_PORT={{ keycloak_https_port }}
 KEYCLOAK_MANAGEMENT_HTTP_PORT={{ keycloak_management_http_port }}
 KEYCLOAK_MANAGEMENT_HTTPS_PORT={{ keycloak_management_https_port }}
 JBOSS_PIDFILE='{{ keycloak_service_pidfile }}'
-LAUNCH_JBOSS_IN_BACKGROUND=1
+
+WILDFLY_OPTS=-Djboss.bind.address=${KEYCLOAK_BIND_ADDRESS} \
+        -Djboss.http.port=${KEYCLOAK_HTTP_PORT} \
+        -Djboss.https.port=${KEYCLOAK_HTTPS_PORT} \
+        -Djboss.management.http.port=${KEYCLOAK_MANAGEMENT_HTTP_PORT} \
+        -Djboss.management.https.port=${KEYCLOAK_MANAGEMENT_HTTPS_PORT} \
+        -Djboss.node.name={{ inventory_hostname }} \
+      {% if keycloak_prefer_ipv4 %}-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true {% endif %}\
+      {% if keycloak_config_standalone_xml is defined %}--server-config={{ keycloak_config_standalone_xml }}{% endif %}

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -8,8 +8,10 @@ StartLimitBurst={{ keycloak_service_startlimitburst }}
 
 [Service]
 Type=forking
+{% if keycloak_service_runas %}
 User={{ keycloak_service_user }}
 Group={{ keycloak_service_group }}
+{% endif -%}
 EnvironmentFile=-/etc/sysconfig/keycloak
 PIDFile={{ keycloak_service_pidfile }}
 ExecStart={{ keycloak_dest }}/keycloak-service.sh start

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -8,6 +8,8 @@ StartLimitBurst={{ keycloak_service_startlimitburst }}
 
 [Service]
 Type=forking
+User={{ keycloak_service_user }}
+Group={{ keycloak_service_group }}
 EnvironmentFile=-/etc/sysconfig/keycloak
 PIDFile={{ keycloak_service_pidfile }}
 ExecStart={{ keycloak_dest }}/keycloak-service.sh start

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -7,15 +7,14 @@ StartLimitBurst={{ keycloak_service_startlimitburst }}
 
 
 [Service]
-Type=forking
 {% if keycloak_service_runas %}
 User={{ keycloak_service_user }}
 Group={{ keycloak_service_group }}
 {% endif -%}
 EnvironmentFile=-/etc/sysconfig/keycloak
 PIDFile={{ keycloak_service_pidfile }}
-ExecStart={{ keycloak_dest }}/keycloak-service.sh start
-ExecStop={{ keycloak_dest }}/keycloak-service.sh stop
+ExecStart={{ keycloak.home }}/bin/standalone.sh $WILDFLY_OPTS
+WorkingDirectory={{ keycloak.home }}
 TimeoutStartSec=30
 TimeoutStopSec=30
 LimitNOFILE=102642

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -17,7 +17,7 @@ keycloak_quarkus_config_dir: "{{ keycloak_quarkus_home }}/conf"
 keycloak_quarkus_start_dev: False
 keycloak_quarkus_service_user: keycloak
 keycloak_quarkus_service_group: keycloak
-keycloak_quarkus_service_pidfile: "/run/keycloak.pid"
+keycloak_quarkus_service_pidfile: "/run/keycloak/keycloak.pid"
 keycloak_quarkus_configure_firewalld: False
 
 ### administrator console password

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -61,7 +61,7 @@ argument_specs:
                 type: "str"
             keycloak_quarkus_service_pidfile:
                 # line 18 of defaults/main.yml
-                default: "/run/keycloak.pid"
+                default: "/run/keycloak/keycloak.pid"
                 description: "Pid file path for service"
                 type: "str"
             keycloak_quarkus_configure_firewalld:


### PR DESCRIPTION
The actual implementation always runs the service as root user.
This PR uses the existing variables `keycloak_service_user` and `keycloak_service_group`  to set the user and group of the startup script and so of the actual java process.
I have also changed the default `keycloak_service_pidfile` value allowing to set the correct permissions on the folder containing the pidfile