### PR TITLE
keycloak_quarkus: skip proxy config if `keycloak_quarkus_proxy_mode` is `none`

### DIFF
--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -49,7 +49,7 @@ keycloak_quarkus_db_enabled: "{{ True if keycloak_quarkus_ha_enabled else False 
 keycloak_quarkus_http_relative_path: auth
 keycloak_quarkus_frontend_url: http://localhost:8080/auth
 
-# proxy address forwarding mode if the server is behind a reverse proxy. [edge, reencrypt, passthrough]
+# proxy address forwarding mode if the server is behind a reverse proxy. [none, edge, reencrypt, passthrough]
 keycloak_quarkus_proxy_mode: edge
 
 # disable xa transactions

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -243,7 +243,7 @@ argument_specs:
             keycloak_quarkus_proxy_mode:
                 default: 'edge'
                 type: "str"
-                description: "The proxy address forwarding mode if the server is behind a reverse proxy"
+                description: "The proxy address forwarding mode if the server is behind a reverse proxy. Set to 'none' if not using a proxy"
             keycloak_quarkus_start_dev:
                 default: False
                 type: "bool"

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -34,8 +34,10 @@ cache-config-file=cache-ispn.xml
 cache-stack=tcp
 {% endif %}
 
+{% if keycloak_quarkus_proxy_mode is defined and keycloak_quarkus_proxy_mode != "none" %}
 # Proxy
 proxy={{ keycloak_quarkus_proxy_mode }}
+{% endif %}
 # Do not attach route to cookies and rely on the session affinity capabilities from reverse proxy
 #spi-sticky-session-encoder-infinispan-should-attach-route=false
 


### PR DESCRIPTION
| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_proxy_mode`| The proxy address forwarding mode if the server is behind a reverse proxy. Allowed values are: [ none, edge, reencrypt, passthrough ] | `edge` |