### PR TITLE
Fix validation failure upon port configuration change

### DIFF
--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -53,7 +53,7 @@
   become: yes
 
 - name: Flush pending handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: "Start and wait for keycloak service"
   ansible.builtin.include_tasks: start.yml

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -52,6 +52,9 @@
     mode: 0775
   become: yes
 
+- name: Flush pending handlers
+  meta: flush_handlers
+
 - name: "Start and wait for keycloak service"
   ansible.builtin.include_tasks: start.yml
 


### PR DESCRIPTION
Ensure to run the `restart keycloak` handler before attempting to validate service status.

Otherwise changing `keycloak_quarkus_http_port` always lead to a failing play because the wait until service up is targeting the new port but the service has not restarted yet.