### PR TITLE
Do not require hosts edit for running quarkus molecule suite locally

### DIFF
--- a/molecule/quarkus/prepare.yml
+++ b/molecule/quarkus/prepare.yml
@@ -7,6 +7,10 @@
         name: sudo
         state: present
 
+    - name: "Display hera_home if defined."
+      ansible.builtin.set_fact:
+        hera_home: "{{ lookup('env', 'HERA_HOME') }}"
+
     - name: Create certificate request
       ansible.builtin.command: openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj '/CN=instance'
       delegate_to: localhost

--- a/molecule/quarkus/prepare.yml
+++ b/molecule/quarkus/prepare.yml
@@ -7,25 +7,10 @@
         name: sudo
         state: present
 
-    - name: "Display hera_home if defined."
-      ansible.builtin.set_fact:
-        hera_home: "{{ lookup('env', 'HERA_HOME') }}"
-
     - name: Create certificate request
       ansible.builtin.command: openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj '/CN=instance'
       delegate_to: localhost
       changed_when: False
-
-    - name: Set /etc/hosts
-      ansible.builtin.lineinfile:
-        dest: /etc/hosts
-        line: "127.0.0.1 instance"
-        state: present
-      delegate_to: localhost
-      become: yes
-      when:
-        - hera_home is defined
-        - hera_home | length == 0
 
     - name: Create conf directory # risky-file-permissions in test user account does not exist yet
       ansible.builtin.file:

--- a/molecule/quarkus/verify.yml
+++ b/molecule/quarkus/verify.yml
@@ -16,11 +16,14 @@
         hera_home: "{{ lookup('env', 'HERA_HOME') }}"
 
     - name: Verify openid config
+      when:
+        - hera_home is defined
+        - hera_home | length == 0
       block:
         - name: Fetch openID config # noqa blocked_modules command-instead-of-module
           ansible.builtin.shell: |
             set -o pipefail
-            curl https://instance:8443/realms/master/.well-known/openid-configuration -k | jq .
+            curl -H 'Host: instance' https://localhost:8443/realms/master/.well-known/openid-configuration -k | jq .
           args:
             executable: /bin/bash
           delegate_to: localhost
@@ -34,6 +37,3 @@
               - (openid_config.stdout | from_json)['authorization_endpoint'] == 'https://instance/realms/master/protocol/openid-connect/auth'
               - (openid_config.stdout | from_json)['token_endpoint'] == 'https://instance/realms/master/protocol/openid-connect/token'
           delegate_to: localhost
-      when:
-        - hera_home is defined
-        - hera_home | length == 0


### PR DESCRIPTION
prepare playbook was failing for me when running quarkus suite locally (can't/won't edit my hosts file via sudo).

If it just for having `curl` in the verify playbook to succeed, this should be enough.

(didn't really understood what this HERA_HOME stuff is for)