### PR TITLE
Update admin password variable in keycloak_quarkus.yml

### DIFF
--- a/playbooks/keycloak_quarkus.yml
+++ b/playbooks/keycloak_quarkus.yml
@@ -2,7 +2,7 @@
 - name: Playbook for Keycloak X Hosts with HTTPS enabled
   hosts: all
   vars:
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_quarkus_host: localhost
     keycloak_quarkus_port: 8443
     keycloak_quarkus_http_relative_path: ''


### PR DESCRIPTION
As defined in the [role documentation](https://github.com/ansible-middleware/keycloak/tree/main/roles/keycloak_quarkus#role-variables) the correct variable to use is `keycloak_quarkus_admin_pass` not `keycloak_admin_password` . 