### PR TITLE
keycloak_quarkus: add hostname-strict parameter

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -50,6 +50,13 @@ Role Defaults
 |`keycloak_quarkus_trust_store_password`| Password for the trust store | `""` |
 
 
+* Hostname configuration
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`keycloak_quarkus_http_relative_path`| Set the path relative to / for serving resources. The path must start with a / | `/` |
+|`keycloak_quarkus_hostname_strict`| Disables dynamically resolving the hostname from request headers | `true` |
+
 
 * Database configuration
 
@@ -118,6 +125,8 @@ Role Variables
 | Variable | Description | Required |
 |:---------|:------------|----------|
 |`keycloak_quarkus_admin_pass`| Password of console admin account | `yes` |
+|`keycloak_quarkus_frontend_url`| Base URL for frontend URLs, including scheme, host, port and path | `no` |
+|`keycloak_quarkus_admin_url`| Base URL for accessing the administration console, including scheme, host, port and path | `no` |
 
 
 License

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -63,6 +63,10 @@ keycloak_quarkus_admin_url:
 ### (set to `/auth` for retrocompatibility with pre-quarkus releases)
 keycloak_quarkus_http_relative_path: /
 
+# Disables dynamically resolving the hostname from request headers.
+# Should always be set to true in production, unless proxy verifies the Host header.
+keycloak_quarkus_hostname_strict: true
+
 # proxy address forwarding mode if the server is behind a reverse proxy. [none, edge, reencrypt, passthrough]
 keycloak_quarkus_proxy_mode: edge
 

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -288,3 +288,7 @@ argument_specs:
                 default: true
                 type: "bool"
                 description: "Enable or disable XA transactions which may not be supported by some DBMS"
+            keycloak_quarkus_hostname_strict:
+                default: true
+                type: "bool"
+                description: "Disables dynamically resolving the hostname from request headers. Should always be set to true in production, unless proxy verifies the Host header."

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -41,6 +41,7 @@ hostname-port={{ keycloak_quarkus_port }}
 hostname-path={{ keycloak_quarkus_path }}
 {% endif %}
 hostname-admin-url={{ keycloak_quarkus_admin_url }}
+hostname-strict={{ keycloak_quarkus_hostname_strict | lower }}
 
 # Cluster
 {% if keycloak_quarkus_ha_enabled %}


### PR DESCRIPTION
New parameter to control `hostname-strict` behaviour

| Parameter | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_hostname_strict`| Disables dynamically resolving the hostname from request headers | `true` |

Warning: Should always be set to true in production, unless proxy verifies the Host header.