### PR TITLE
keycloak_quarkus: allow ports <1024 (e.g. :443) in systemd unit

### DIFF
--- a/roles/keycloak_quarkus/templates/keycloak.service.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.service.j2
@@ -20,6 +20,9 @@ Restart=always
 Restart=on-failure
 {% endif %}
 RestartSec={{ keycloak_quarkus_service_restartsec }}
+{% if keycloak_quarkus_http_port|int < 1024 or keycloak_quarkus_https_port|int < 1024 %}
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix #149