### PR TITLE
keycloak_quarkus: allow configuration of `hostname-strict-backchannel`

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -56,6 +56,7 @@ Role Defaults
 |:---------|:------------|:--------|
 |`keycloak_quarkus_http_relative_path`| Set the path relative to / for serving resources. The path must start with a / | `/` |
 |`keycloak_quarkus_hostname_strict`| Disables dynamically resolving the hostname from request headers | `true` |
+|`keycloak_quarkus_hostname_strict_backchannel`| By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. If all applications use the public URL this option should be enabled. | `false` |
 
 
 * Database configuration

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -66,6 +66,9 @@ keycloak_quarkus_http_relative_path: /
 # Disables dynamically resolving the hostname from request headers.
 # Should always be set to true in production, unless proxy verifies the Host header.
 keycloak_quarkus_hostname_strict: true
+# By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications.
+# If all applications use the public URL this option should be enabled.
+keycloak_quarkus_hostname_strict_backchannel: false
 
 # proxy address forwarding mode if the server is behind a reverse proxy. [none, edge, reencrypt, passthrough]
 keycloak_quarkus_proxy_mode: edge

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -292,6 +292,10 @@ argument_specs:
                 default: true
                 type: "bool"
                 description: "Disables dynamically resolving the hostname from request headers. Should always be set to true in production, unless proxy verifies the Host header."
+            keycloak_quarkus_hostname_strict_backchannel:
+                default: false
+                type: "bool"
+                description: "By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. If all applications use the public URL this option should be enabled."
     downstream:
         options:
             rhbk_version:

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -42,6 +42,7 @@ hostname-path={{ keycloak_quarkus_path }}
 {% endif %}
 hostname-admin-url={{ keycloak_quarkus_admin_url }}
 hostname-strict={{ keycloak_quarkus_hostname_strict | lower }}
+hostname-strict-backchannel={{ keycloak_quarkus_hostname_strict_backchannel | lower }}
 
 # Cluster
 {% if keycloak_quarkus_ha_enabled %}


### PR DESCRIPTION
Fix #151 