### PR TITLE
fix/#153: keycloak_quarkus: Use `keycloak_quarkus_java_opts`

### DIFF
--- a/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
@@ -3,3 +3,4 @@ KEYCLOAK_ADMIN={{ keycloak_quarkus_admin_user }}
 KEYCLOAK_ADMIN_PASSWORD='{{ keycloak_quarkus_admin_pass }}'
 PATH={{ keycloak_java_home  | default(keycloak_rpm_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 JAVA_HOME={{ keycloak_java_home  | default(keycloak_rpm_java_home, true) }}
+JAVA_OPTS_APPEND={{ keycloak_quarkus_java_opts }}


### PR DESCRIPTION
Note: when multiple -X options of the same kind are provided, the last option seems to take precendence as per <https://stackoverflow.com/a/26727332>:

> java -Xmx1G -XX:+PrintFlagsFinal -Xmx2G 2>/dev/null | grep MaxHeapSize