### PR TITLE
keycloak_quarkus: renamed infinispan host list configuration

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: middleware_automation
 name: keycloak
-version: "2.0.3"
+version: "2.1.0"
 readme: README.md
 authors:
   - Romain Pelisse <rpelisse@redhat.com>

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -79,7 +79,7 @@ Role Defaults
 |:---------|:------------|:--------|
 |`keycloak_quarkus_ispn_user` | Username for connecting to infinispan | `supervisor` |
 |`keycloak_quarkus_ispn_pass` | Password for connecting to infinispan | `supervisor` |
-|`keycloak_quarkus_ispn_url` | URL for connecting to infinispan | `localhost` |
+|`keycloak_quarkus_ispn_hosts` | host name/port for connecting to infinispan, eg. host1:11222;host2:11222 | `localhost:11222` |
 |`keycloak_quarkus_ispn_sasl_mechanism` | Infinispan auth mechanism | `SCRAM-SHA-512` |
 |`keycloak_quarkus_ispn_use_ssl` | Whether infinispan uses TLS connection | `false` |
 |`keycloak_quarkus_ispn_trust_store_path` | Path to infinispan server trust certificate | `/etc/pki/java/cacerts` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -85,7 +85,7 @@ keycloak_quarkus_health_enabled: true
 ### infinispan remote caches access (hotrod)
 keycloak_quarkus_ispn_user: supervisor
 keycloak_quarkus_ispn_pass: supervisor
-keycloak_quarkus_ispn_url: localhost
+keycloak_quarkus_ispn_hosts: "localhost:11222"
 keycloak_quarkus_ispn_sasl_mechanism: SCRAM-SHA-512
 keycloak_quarkus_ispn_use_ssl: false
 # if ssl is enabled, import ispn server certificate here

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -218,10 +218,10 @@ argument_specs:
                 default: "supervisor"
                 description: "Password for connecting to infinispan"
                 type: "str"
-            keycloak_quarkus_ispn_url:
+            keycloak_quarkus_ispn_hosts:
                 # line 48 of defaults/main.yml
-                default: "localhost"
-                description: "URL for connecting to infinispan"
+                default: "localhost:11222"
+                description: "host name/port for connecting to infinispan, eg. host1:11222;host2:11222"
                 type: "str"
             keycloak_quarkus_ispn_sasl_mechanism:
                 # line 49 of defaults/main.yml

--- a/roles/keycloak_quarkus/templates/quarkus.properties.j2
+++ b/roles/keycloak_quarkus/templates/quarkus.properties.j2
@@ -1,10 +1,16 @@
 # {{ ansible_managed }}
 {% if keycloak_quarkus_ha_enabled %}
-quarkus.infinispan-client.server-list={{ keycloak_quarkus_ispn_url }}
-quarkus.infinispan-client.client-intelligence=HASH_DISTRIBUTION_AWARE
-quarkus.infinispan-client.use-auth=true
+{% if not rhbk_enable or keycloak_quarkus_version.split('.')[0]|int < 22 %}
+quarkus.infinispan-client.server-list={{ keycloak_quarkus_ispn_hosts }}
 quarkus.infinispan-client.auth-username={{ keycloak_quarkus_ispn_user }}
 quarkus.infinispan-client.auth-password={{ keycloak_quarkus_ispn_pass }}
+{% else %}
+quarkus.infinispan-client.hosts={{ keycloak_quarkus_ispn_hosts }}
+quarkus.infinispan-client.username={{ keycloak_quarkus_ispn_user }}
+quarkus.infinispan-client.password={{ keycloak_quarkus_ispn_pass }}
+{% endif %}
+quarkus.infinispan-client.client-intelligence=HASH_DISTRIBUTION_AWARE
+quarkus.infinispan-client.use-auth=true
 quarkus.infinispan-client.auth-realm=default
 quarkus.infinispan-client.auth-server-name=infinispan
 quarkus.infinispan-client.sasl-mechanism={{ keycloak_quarkus_ispn_sasl_mechanism }}
@@ -14,6 +20,4 @@ quarkus.infinispan-client.trust-store-password={{ keycloak_quarkus_ispn_trust_st
 quarkus.infinispan-client.trust-store-type=jks
 {% endif %}
 #quarkus.infinispan-client.use-schema-registration=true
-#quarkus.infinispan-client.auth-client-subject
-#quarkus.infinispan-client.auth-callback-handler
 {% endif %}


### PR DESCRIPTION
This changeset contains a parameter rename for the `keycloak_quarkus` role, which reflects a renaming that happened in the upstream project. 

The removed parameter is `keycloak_quarkus_ispn_url`, which is superseeded by:


| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_ispn_hosts` | semicolon separated `hostname:port` for connecting to infinispan, eg. `host1:11222;host2:11222` | `localhost:11222` |


Fix #146 
Fix #156 