### PR TITLE
#158: Feature/inifinispan TCPPING

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -19,6 +19,7 @@ Role Defaults
 | Variable | Description | Default |
 |:---------|:------------|:--------|
 |`keycloak_quarkus_ha_enabled`| Enable auto configuration for database backend, clustering and remote caches on infinispan | `False` |
+|`keycloak_quarkus_ha_discovery`| Discovery protocol for HA cluster members | `TCPPING` |
 |`keycloak_quarkus_db_enabled`| Enable auto configuration for database backend | `True` if `keycloak_quarkus_ha_enabled` is True, else `False` |
 |`keycloak_quarkus_admin_user`| Administration console user account | `admin` |
 |`keycloak_quarkus_bind_address`| Address for binding service ports | `0.0.0.0` |
@@ -28,7 +29,7 @@ Role Defaults
 |`keycloak_quarkus_http_port`| HTTP listening port | `8080` |
 |`keycloak_quarkus_https_port`| TLS HTTP listening port | `8443` |
 |`keycloak_quarkus_ajp_port`| AJP port | `8009` |
-|`keycloak_quarkus_jgroups_port`| jgroups cluster tcp port | `7600` |
+|`keycloak_quarkus_jgroups_port`| jgroups cluster tcp port | `7800` |
 |`keycloak_quarkus_service_user`| Posix account username | `keycloak` |
 |`keycloak_quarkus_service_group`| Posix account group | `keycloak` |
 |`keycloak_quarkus_service_restart_always`| systemd restart always behavior activation | `False` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -37,7 +37,7 @@ keycloak_quarkus_http_enabled: true
 keycloak_quarkus_http_port: 8080
 keycloak_quarkus_https_port: 8443
 keycloak_quarkus_ajp_port: 8009
-keycloak_quarkus_jgroups_port: 7600
+keycloak_quarkus_jgroups_port: 7800
 keycloak_quarkus_java_opts: "-Xms1024m -Xmx2048m"
 
 ### TLS/HTTPS configuration
@@ -55,6 +55,7 @@ keycloak_quarkus_trust_store_password: ''
 
 ### Enable configuration for database backend, clustering and remote caches on infinispan
 keycloak_quarkus_ha_enabled: false
+keycloak_quarkus_ha_discovery: "TCPPING"
 ### Enable database configuration, must be enabled when HA is configured
 keycloak_quarkus_db_enabled: "{{ True if keycloak_quarkus_ha_enabled else False }}"
 

--- a/roles/keycloak_quarkus/handlers/main.yml
+++ b/roles/keycloak_quarkus/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+# handler should be invoked anytime a [build configuration](https://www.keycloak.org/server/all-config?f=build) changes
+- name: "Rebuild {{ keycloak.service_name }} config"
+  ansible.builtin.include_tasks: rebuild_config.yml
+  listen: "rebuild keycloak config"
 - name: "Restart {{ keycloak.service_name }}"
   ansible.builtin.include_tasks: restart.yml
   listen: "restart keycloak"

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -168,7 +168,7 @@ argument_specs:
                 type: "int"
             keycloak_quarkus_jgroups_port:
                 # line 32 of defaults/main.yml
-                default: 7600
+                default: 7800
                 description: "jgroups cluster tcp port"
                 type: "int"
             keycloak_quarkus_java_opts:
@@ -181,6 +181,10 @@ argument_specs:
                 default: false
                 description: "Enable auto configuration for database backend, clustering and remote caches on infinispan"
                 type: "bool"
+            keycloak_quarkus_ha_discovery:
+                default: "TCPPING"
+                description: "Discovery protocol for HA cluster members"
+                type: "str"
             keycloak_quarkus_db_enabled:
                 # line 38 of defaults/main.yml
                 default: "{{ True if keycloak_quarkus_ha_enabled else False }}"

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -43,6 +43,17 @@
   notify:
     - restart keycloak
 
+- name: "Configure infinispan config for keycloak service"
+  ansible.builtin.template:
+    src: cache-ispn.xml
+    dest: "{{ keycloak.home }}/conf/cache-ispn.xml"
+    owner: "{{ keycloak.service_user }}"
+    group: "{{ keycloak.service_group }}"
+    mode: 0644
+  become: true
+  notify:
+    - restart keycloak
+
 - name: Ensure logdirectory exists
   ansible.builtin.file:
     state: directory

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -30,6 +30,7 @@
     mode: 0644
   become: true
   notify:
+    - rebuild keycloak config
     - restart keycloak
 
 - name: "Configure quarkus config for keycloak service"
@@ -43,6 +44,20 @@
   notify:
     - restart keycloak
 
+- name: Create tcpping cluster node list
+  ansible.builtin.set_fact:
+    keycloak_quarkus_cluster_nodes: >
+      {{ keycloak_quarkus_cluster_nodes | default([]) + [
+        {
+          "name": item,
+          "address": 'jgroups-' + item,
+          "inventory_host": hostvars[item].ansible_default_ipv4.address | default(item) + '[' + (keycloak_quarkus_jgroups_port | string) + ']',
+          "value": hostvars[item].ansible_default_ipv4.address | default(item)
+        }
+      ] }}
+  loop: "{{ ansible_play_batch }}"
+  when: keycloak_quarkus_ha_enabled and keycloak_quarkus_ha_discovery == 'TCPPING'
+
 - name: "Configure infinispan config for keycloak service"
   ansible.builtin.template:
     src: cache-ispn.xml
@@ -52,6 +67,7 @@
     mode: 0644
   become: true
   notify:
+    - rebuild keycloak config
     - restart keycloak
 
 - name: Ensure logdirectory exists

--- a/roles/keycloak_quarkus/tasks/rebuild_config.yml
+++ b/roles/keycloak_quarkus/tasks/rebuild_config.yml
@@ -1,0 +1,7 @@
+---
+# cf. https://www.keycloak.org/server/configuration#_optimize_the_keycloak_startup
+- name: "Rebuild {{ keycloak.service_name }} config"
+  ansible.builtin.shell: |
+    {{ keycloak.home }}/bin/kc.sh build
+  become: true
+  changed_when: true

--- a/roles/keycloak_quarkus/templates/cache-ispn.xml
+++ b/roles/keycloak_quarkus/templates/cache-ispn.xml
@@ -1,0 +1,85 @@
+# {{ ansible_managed }}
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:14.0 http://www.infinispan.org/schemas/infinispan-config-14.0.xsd"
+        xmlns="urn:infinispan:config:14.0">
+
+    <cache-container name="keycloak">
+        <transport lock-timeout="60000"/>
+        <local-cache name="realms" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <local-cache name="users" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <distributed-cache name="sessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="authenticationSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="offlineSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="clientSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="offlineClientSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="loginFailures" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <local-cache name="authorization" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <replicated-cache name="work">
+            <expiration lifespan="-1"/>
+        </replicated-cache>
+        <local-cache name="keys" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="3600000"/>
+            <memory max-count="1000"/>
+        </local-cache>
+        <distributed-cache name="actionTokens" owners="2">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+            <memory max-count="-1"/>
+        </distributed-cache>
+    </cache-container>
+</infinispan>

--- a/roles/keycloak_quarkus/templates/cache-ispn.xml
+++ b/roles/keycloak_quarkus/templates/cache-ispn.xml
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+<!-- {{ ansible_managed }} -->
 <!--
   ~ Copyright 2019 Red Hat, Inc. and/or its affiliates
   ~ and other contributors as indicated by the @author tags.
@@ -21,8 +21,24 @@
         xsi:schemaLocation="urn:infinispan:config:14.0 http://www.infinispan.org/schemas/infinispan-config-14.0.xsd"
         xmlns="urn:infinispan:config:14.0">
 
+{% set stack_expression='' %}
+{% if keycloak_quarkus_ha_enabled and keycloak_quarkus_ha_discovery == 'TCPPING' %}
+{% set stack_expression='stack="tcpping"' %}
+    <jgroups>
+        <stack name="tcpping" extends="tcp">
+            <!-- <TCP external_addr="${env.KC_EXTERNAL_ADDR}" bind_addr="{{ keycloak_quarkus_bind_address }}" bind_port="{{ keycloak_quarkus_jgroups_port }}" /> -->
+            <TCPPING
+                initial_hosts="{{ keycloak_quarkus_cluster_nodes | map(attribute='inventory_host') | join (',') }}"
+                port_range="0"
+                stack.combine="REPLACE"
+                stack.position="MPING"
+            />
+        </stack>
+    </jgroups>
+{% endif %}
+
     <cache-container name="keycloak">
-        <transport lock-timeout="60000"/>
+        <transport lock-timeout="60000" {{ stack_expression }}/>
         <local-cache name="realms" simple-cache="true">
             <encoding>
                 <key media-type="application/x-java-object"/>

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -48,7 +48,9 @@ hostname-strict-backchannel={{ keycloak_quarkus_hostname_strict_backchannel | lo
 {% if keycloak_quarkus_ha_enabled %}
 cache=ispn
 cache-config-file=cache-ispn.xml
-cache-stack=tcp
+{% if keycloak_quarkus_ha_enabled and keycloak_quarkus_ha_discovery == 'TCPPING' %}
+# cache-stack=tcp # configured directly in `cache-ispn.xml`
+{% endif %}
 {% endif %}
 
 {% if keycloak_quarkus_proxy_mode is defined and keycloak_quarkus_proxy_mode != "none" %}

--- a/roles/keycloak_quarkus/templates/keycloak.service.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.service.j2
@@ -10,7 +10,7 @@ PIDFile={{ keycloak_quarkus_service_pidfile }}
 {% if keycloak_quarkus_start_dev %}
 ExecStart={{ keycloak.home }}/bin/kc.sh start-dev
 {% else %}
-ExecStart={{ keycloak.home }}/bin/kc.sh start --log={{ keycloak_quarkus_log }}
+ExecStart={{ keycloak.home }}/bin/kc.sh start --optimized
 {% endif %}
 User={{ keycloak.service_user }}
 Group={{ keycloak.service_group }}


### PR DESCRIPTION
* changes port of TCPPING to 7800/tcp (was: 7600/tcp, based on JDBCPING which was default in keycloak role)
* adds `kc.sh build` invocation in order to minimize startup time; moreover, I had issues with getting TCPPING config to work since  keycloak, upon a regular invocation of `kc.sh start` creates it's own internal cache which is kept until a build is re-run; this newly added handler will save us some headaches in future
* adds `kc.sh start --optimized` in case `--start-dev` is not executed, thus re-using the aforementioned pre-built configuration

Fix #158 