### PR TITLE
keycloak_quarkus: Allow configuring log rotate options in quarkus configuration

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -116,6 +116,9 @@ Role Defaults
 |`keycloak_quarkus_log_file`| Set the log file path and filename relative to keycloak home | `data/log/keycloak.log` |
 |`keycloak_quarkus_log_format`| Set a format specific to file log entries | `%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n` |
 |`keycloak_quarkus_log_target`| Set the destination of the keycloak log folder link | `/var/log/keycloak` |
+|`keycloak_quarkus_log_max_file_size`| Set the maximum log file size before a log rotation happens; A size configuration option recognises string in this format (shown as a regular expression): [0-9]+[KkMmGgTtPpEeZzYy]?. If no suffix is given, assume bytes." | `10M`
+|`keycloak_quarkus_log_max_backup_index`| Set the maximum number of archived log files to keep" | `10`
+|`keycloak_quarkus_log_file_suffix`| Set the log file handler rotation file suffix. When used, the file will be rotated based on its suffix; Note: If the suffix ends with `.zip` or `.gz`, the rotation file will also be compressed." | `.yyyy-MM-dd.zip`
 |`keycloak_quarkus_proxy_mode`| The proxy address forwarding mode if the server is behind a reverse proxy | `edge` |
 |`keycloak_quarkus_start_dev`| Whether to start the service in development mode (start-dev) | `False` |
 |`keycloak_quarkus_transaction_xa_enabled`| Whether to use XA transactions | `True` |

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -116,9 +116,9 @@ Role Defaults
 |`keycloak_quarkus_log_file`| Set the log file path and filename relative to keycloak home | `data/log/keycloak.log` |
 |`keycloak_quarkus_log_format`| Set a format specific to file log entries | `%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n` |
 |`keycloak_quarkus_log_target`| Set the destination of the keycloak log folder link | `/var/log/keycloak` |
-|`keycloak_quarkus_log_max_file_size`| Set the maximum log file size before a log rotation happens; A size configuration option recognises string in this format (shown as a regular expression): [0-9]+[KkMmGgTtPpEeZzYy]?. If no suffix is given, assume bytes." | `10M`
-|`keycloak_quarkus_log_max_backup_index`| Set the maximum number of archived log files to keep" | `10`
-|`keycloak_quarkus_log_file_suffix`| Set the log file handler rotation file suffix. When used, the file will be rotated based on its suffix; Note: If the suffix ends with `.zip` or `.gz`, the rotation file will also be compressed." | `.yyyy-MM-dd.zip`
+|`keycloak_quarkus_log_max_file_size`| Set the maximum log file size before a log rotation happens; A size configuration option recognises string in this format (shown as a regular expression): `[0-9]+[KkMmGgTtPpEeZzYy]?`. If no suffix is given, assume bytes. | `10M` |
+|`keycloak_quarkus_log_max_backup_index`| Set the maximum number of archived log files to keep" | `10` |
+|`keycloak_quarkus_log_file_suffix`| Set the log file handler rotation file suffix. When used, the file will be rotated based on its suffix; Note: If the suffix ends with `.zip` or `.gz`, the rotation file will also be compressed. | `.yyyy-MM-dd.zip` |
 |`keycloak_quarkus_proxy_mode`| The proxy address forwarding mode if the server is behind a reverse proxy | `edge` |
 |`keycloak_quarkus_start_dev`| Whether to start the service in development mode (start-dev) | `False` |
 |`keycloak_quarkus_transaction_xa_enabled`| Whether to use XA transactions | `True` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -117,3 +117,6 @@ keycloak_quarkus_log_level: info
 keycloak_quarkus_log_file: data/log/keycloak.log
 keycloak_quarkus_log_format: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
 keycloak_quarkus_log_target: /var/log/keycloak
+keycloak_quarkus_log_max_file_size: 10M
+keycloak_quarkus_log_max_backup_index: 10
+keycloak_quarkus_log_file_suffix: '.yyyy-MM-dd.zip'

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -288,6 +288,18 @@ argument_specs:
                 default: '/var/log/keycloak'
                 type: "str"
                 description: "Set the destination of the keycloak log folder link"
+            keycloak_quarkus_log_max_file_size:
+                default: 10M
+                type: "str"
+                description: "Set the maximum log file size before a log rotation happens; A size configuration option recognises string in this format (shown as a regular expression): [0-9]+[KkMmGgTtPpEeZzYy]?. If no suffix is given, assume bytes."
+            keycloak_quarkus_log_max_backup_index:
+                default: 10
+                type: "str"
+                description: "Set the maximum number of archived log files to keep"
+            keycloak_quarkus_log_file_suffix:
+                default: '.yyyy-MM-dd.zip'
+                type: "str"
+                description: "Set the log file handler rotation file suffix. When used, the file will be rotated based on its suffix; Note: If the suffix ends with .zip or .gz, the rotation file will also be compressed."
             keycloak_quarkus_proxy_mode:
                 default: 'edge'
                 type: "str"

--- a/roles/keycloak_quarkus/templates/quarkus.properties.j2
+++ b/roles/keycloak_quarkus/templates/quarkus.properties.j2
@@ -21,3 +21,6 @@ quarkus.infinispan-client.trust-store-type=jks
 {% endif %}
 #quarkus.infinispan-client.use-schema-registration=true
 {% endif %}
+quarkus.log.file.rotation.max-file-size={{ keycloak_quarkus_log_max_file_size }}
+quarkus.log.file.rotation.max-backup-index={{ keycloak_quarkus_log_max_backup_index }}
+quarkus.log.file.rotation.file-suffix={{ keycloak_quarkus_log_file_suffix }}


### PR DESCRIPTION
New role parameters allow to tweak log rotation:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_log_max_file_size`| Set the maximum log file size before a log rotation happens; A size configuration option recognises string in this format (shown as a regular expression): `[0-9]+[KkMmGgTtPpEeZzYy]?`. If no suffix is given, assume bytes. | `10M` |
|`keycloak_quarkus_log_max_backup_index`| Set the maximum number of archived log files to keep" | `10` |
|`keycloak_quarkus_log_file_suffix`| Set the log file handler rotation file suffix. When used, the file will be rotated based on its suffix; Note: If the suffix ends with `.zip` or `.gz`, the rotation file will also be compressed. | `.yyyy-MM-dd.zip` |


Fix #160 