### PR TITLE
keycloak_quarkus: `sticky-session`s for infinispan routes

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -119,7 +119,7 @@ Role Defaults
 |`keycloak_quarkus_proxy_mode`| The proxy address forwarding mode if the server is behind a reverse proxy | `edge` |
 |`keycloak_quarkus_start_dev`| Whether to start the service in development mode (start-dev) | `False` |
 |`keycloak_quarkus_transaction_xa_enabled`| Whether to use XA transactions | `True` |
-
+|`keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route`| If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies and we rely on the session affinity capabilities from reverse proxy | `True` |
 
 Role Variables
 --------------

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -79,6 +79,9 @@ keycloak_quarkus_proxy_mode: edge
 # disable xa transactions
 keycloak_quarkus_transaction_xa_enabled: true
 
+# If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies and we rely on the session affinity capabilities from reverse proxy
+keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route: true
+
 keycloak_quarkus_metrics_enabled: false
 keycloak_quarkus_health_enabled: true
 

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -308,6 +308,10 @@ argument_specs:
                 default: false
                 type: "bool"
                 description: "By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. If all applications use the public URL this option should be enabled."
+            keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route:
+                default: true
+                type: "bool"
+                description: "If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies and we rely on the session affinity capabilities from reverse proxy"
     downstream:
         options:
             rhbk_version:

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -55,8 +55,7 @@ cache-stack=tcp
 # Proxy
 proxy={{ keycloak_quarkus_proxy_mode }}
 {% endif %}
-# Do not attach route to cookies and rely on the session affinity capabilities from reverse proxy
-#spi-sticky-session-encoder-infinispan-should-attach-route=false
+spi-sticky-session-encoder-infinispan-should-attach-route={{ keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route | d(true) | lower }}
 
 # Transaction
 transaction-xa-enabled={{ keycloak_quarkus_transaction_xa_enabled | lower }}


### PR DESCRIPTION
New extremely long unimaginatively named parameter (do not blame the collection):

| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route`| If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies and we rely on the session affinity capabilities from reverse proxy | `True` |

allows to configure the corresponding option.

Fix #163