### PR TITLE
Set enable-recovery when xa transactions are enabled

### DIFF
--- a/roles/keycloak_quarkus/templates/quarkus.properties.j2
+++ b/roles/keycloak_quarkus/templates/quarkus.properties.j2
@@ -24,3 +24,6 @@ quarkus.infinispan-client.trust-store-type=jks
 quarkus.log.file.rotation.max-file-size={{ keycloak_quarkus_log_max_file_size }}
 quarkus.log.file.rotation.max-backup-index={{ keycloak_quarkus_log_max_backup_index }}
 quarkus.log.file.rotation.file-suffix={{ keycloak_quarkus_log_file_suffix }}
+{% if keycloak_quarkus_db_enabled %}
+quarkus.transaction-manager.enable-recovery=true
+{% endif %}


### PR DESCRIPTION
Since when XA-transaction default was set to true, bootstrapping produces the following warning:

```
WARN [io.quarkus.agroal.runtime.DataSources] (main) Datasource <default> enables XA but transaction recovery is not enabled. 
Please enable transaction recovery by setting quarkus.transaction-manager.enable-recovery=true, 
otherwise data may be lost if the application is terminated abruptly
```

