### PR TITLE
keycloak_quarkus: fix custom JAVA_HOME parameter name

### DIFF
--- a/molecule/https_revproxy/prepare.yml
+++ b/molecule/https_revproxy/prepare.yml
@@ -33,6 +33,7 @@
       ansible.builtin.file:
         path: /etc/nginx/tls
         state: directory
+        mode: 0755
     - name: Copy certificates
       ansible.builtin.copy:
         src: "{{ item.name }}"

--- a/molecule/quarkus-devmode/converge.yml
+++ b/molecule/quarkus-devmode/converge.yml
@@ -9,6 +9,7 @@
     keycloak_quarkus_frontend_url: 'http://localhost:8080/'
     keycloak_quarkus_start_dev: True
     keycloak_quarkus_proxy_mode: none
+    keycloak_quarkus_java_home: /opt/openjdk/
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm

--- a/molecule/quarkus-devmode/prepare.yml
+++ b/molecule/quarkus-devmode/prepare.yml
@@ -4,8 +4,17 @@
   tasks:
     - name: Install sudo
       ansible.builtin.yum:
-        name: sudo
+        name:
+          - sudo
+          - java-17-openjdk-headless
         state: present
+
+    - name: Link default logs directory
+      ansible.builtin.file:
+        state: link
+        src: /usr/lib/jvm/jre-17-openjdk
+        dest: /opt/openjdk
+        force: true
 
     - name: "Display hera_home if defined."
       ansible.builtin.set_fact:

--- a/molecule/quarkus-devmode/verify.yml
+++ b/molecule/quarkus-devmode/verify.yml
@@ -11,6 +11,14 @@
           - ansible_facts.services["keycloak.service"]["state"] == "running"
           - ansible_facts.services["keycloak.service"]["status"] == "enabled"
 
+    - name: Verify we are running on requested JAVA_HOME # noqa blocked_modules command-instead-of-module
+      ansible.builtin.shell: |
+        set -o pipefail
+        ps -ef | grep '/opt/openjdk' | grep -v grep
+      args:
+        executable: /bin/bash
+      changed_when: False
+
     - name: Set internal envvar
       ansible.builtin.set_fact:
         hera_home: "{{ lookup('env', 'HERA_HOME') }}"

--- a/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 KEYCLOAK_ADMIN={{ keycloak_quarkus_admin_user }}
 KEYCLOAK_ADMIN_PASSWORD='{{ keycloak_quarkus_admin_pass }}'
-PATH={{ keycloak_java_home  | default(keycloak_rpm_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-JAVA_HOME={{ keycloak_java_home  | default(keycloak_rpm_java_home, true) }}
+PATH={{ keycloak_quarkus_java_home | default(keycloak_rpm_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+JAVA_HOME={{ keycloak_quarkus_java_home | default(keycloak_rpm_java_home, true) }}
 JAVA_OPTS_APPEND={{ keycloak_quarkus_java_opts }}


### PR DESCRIPTION
Fix parameter documented as `keycloak_quarkus_java_home`, but internally referred as `keycloak_java_home`, to be referenced as `keycloak_quarkus_java_home`

Fix #170 