### PR TITLE
Utilize comment filter for `ansible_managed` annotations

### DIFF
--- a/molecule/overridexml/templates/custom.xml.j2
+++ b/molecule/overridexml/templates/custom.xml.j2
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- {{ ansible_managed }} -->
+{{ ansible_managed | comment('xml') }}
 <server xmlns="urn:jboss:domain:16.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/roles/keycloak/templates/15.0.8/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/15.0.8/standalone-infinispan.xml.j2
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- {{ ansible_managed }} -->
+{{ ansible_managed | comment('xml') }}
 <server xmlns="urn:jboss:domain:16.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/roles/keycloak/templates/15.0.8/standalone.xml.j2
+++ b/roles/keycloak/templates/15.0.8/standalone.xml.j2
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- {{ ansible_managed }} -->
+{{ ansible_managed | comment('xml') }}
 <server xmlns="urn:jboss:domain:16.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/roles/keycloak/templates/keycloak-service.sh.j2
+++ b/roles/keycloak/templates/keycloak-service.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 set +u -o pipefail
 

--- a/roles/keycloak/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak/templates/keycloak-sysconfig.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 JAVA_OPTS='{{ keycloak_java_opts }}'
 JAVA_HOME={{ keycloak_java_home  | default(keycloak_rpm_java_home, true) }}
 JBOSS_HOME={{ keycloak.home }}

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 [Unit]
 Description={{ keycloak.service_name }} Server
 After=network.target

--- a/roles/keycloak/templates/standalone-ha.xml.j2
+++ b/roles/keycloak/templates/standalone-ha.xml.j2
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- {{ ansible_managed }} -->
+{{ ansible_managed | comment('xml') }}
 <server xmlns="urn:jboss:domain:16.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- {{ ansible_managed }} -->
+{{ ansible_managed | comment('xml') }}
 <server xmlns="urn:jboss:domain:16.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/roles/keycloak/templates/standalone.xml.j2
+++ b/roles/keycloak/templates/standalone.xml.j2
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- {{ ansible_managed }} -->
+{{ ansible_managed | comment('xml') }}
 <server xmlns="urn:jboss:domain:16.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/roles/keycloak_quarkus/templates/cache-ispn.xml.j2
+++ b/roles/keycloak_quarkus/templates/cache-ispn.xml.j2
@@ -1,4 +1,4 @@
-<!-- {{ ansible_managed }} -->
+{{ ansible_managed | comment('xml') }}
 <!--
   ~ Copyright 2019 Red Hat, Inc. and/or its affiliates
   ~ and other contributors as indicated by the @author tags.

--- a/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 KEYCLOAK_ADMIN={{ keycloak_quarkus_admin_user }}
 KEYCLOAK_ADMIN_PASSWORD='{{ keycloak_quarkus_admin_pass }}'
 PATH={{ keycloak_quarkus_java_home | default(keycloak_rpm_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% if keycloak_quarkus_db_enabled %}
 # Database

--- a/roles/keycloak_quarkus/templates/keycloak.service.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.service.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 [Unit]
 Description=Keycloak Server
 After=network.target

--- a/roles/keycloak_quarkus/templates/quarkus.properties.j2
+++ b/roles/keycloak_quarkus/templates/quarkus.properties.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% if keycloak_quarkus_ha_enabled %}
 {% if not rhbk_enable or keycloak_quarkus_version.split('.')[0]|int < 22 %}
 quarkus.infinispan-client.server-list={{ keycloak_quarkus_ispn_hosts }}


### PR DESCRIPTION
# What 
Changes all template files that include the ```{{ ansible_managed }}``` annotation  to include  ```{{ ansible_managed | comment  }}``` or, in case of XML templates , ```{{ ansible_managed | comment('xml')  }}``` instead. 
Documentation: [Ansible: manipulating-text](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#manipulating-text)
# Why
The ```{{ ansible_managed }}``` vairable is configurable via the ```ansible.cfg``` file and can be a **multiline string** in which case the form ```# {{ ansible_managed }}``` used in keycloak.conf.j2,  keycloak.service.j2 and keycloak-sysconfig.j2 breaks the file. XML templates that use ```<!-- {{ ansible_managed }} -->``` are ok and I only changed them for consistency.
## Example

```ansible.cfg```
```
ansible_managed = WARNING: This file is managed by ANSIBLE.
  template: {file}
  modified on: %Y-%m-%d %H:%M:%S
  by user: {uid}
```
```# {{ ansible_managed }}``` renders an invalid unit file:

```
# WARNING: This file is managed by ANSIBLE.
 template: roles/keycloak/templates/keycloak.service.j2
 modified on: 2024-03-13 00:39:13
 by user: root
[Unit]
Description=Keycloak Server
After=network.target
...
```
The Service can still be started but no longer enabled. Verify with ```systemd-analyze```
```# systemd-analyze verify /etc/systemd/system/keycloak.service```
```
/etc/systemd/system/keycloak.service:2: Assignment outside of section. Ignoring.
/etc/systemd/system/keycloak.service:3: Assignment outside of section. Ignoring.
/etc/systemd/system/keycloak.service:4: Assignment outside of section. Ignoring.
```

```{{ ansible_managed | comment  }}``` renders a valid unit file:
```
#
# WARNING: This file is managed by ANSIBLE.
# template: roles/keycloak/templates/keycloak.service.j2
# modified on: 2024-03-13 00:39:25
# by user: root
#
[Unit]
Description=Keycloak Server
After=network.target
...
```
# Side Effects 
None