### PR TITLE
JVM arguments go in JAVA_OPTS

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -52,7 +52,7 @@
   pre_tasks:
     - name: "Retrieve assets server from env"
       ansible.builtin.set_fact:
-        assets_server: "{{ lookup('env','MIDDLEWARE_DOWNLOAD_RELEASE_SERVER_URL') }}"
+        assets_server: "{{ lookup('env', 'MIDDLEWARE_DOWNLOAD_RELEASE_SERVER_URL') }}"
 
     - name: "Set offline when assets server from env is defined"
       ansible.builtin.set_fact:

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -38,7 +38,9 @@ Role Defaults
 |`keycloak_quarkus_service_pidfile`| Pid file path for service | `/run/keycloak.pid` |
 |`keycloak_quarkus_jvm_package`| RHEL java package runtime | `java-17-openjdk-headless` |
 |`keycloak_quarkus_java_home`| JAVA_HOME of installed JRE, leave empty for using specified keycloak_quarkus_jvm_package RPM path | `None` |
-|`keycloak_quarkus_java_opts`| Additional JVM options | `-Xms1024m -Xmx2048m` |
+|`keycloak_quarkus_java_opts`| Heap memory JVM setting | `-Xms1024m -Xmx2048m` |
+|`keycloak_quarkus_java_jvm_opts`| Other JVM settings | same as keycloak |
+|`keycloak_quarkus_java_opts`| JVM arguments; if overriden, it takes precedence over `keycloak_quarkus_java_*` | `{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}` |
 |`keycloak_quarkus_frontend_url`| Set the base URL for frontend URLs, including scheme, host, port and path | |
 |`keycloak_quarkus_admin_url`| Set the base URL for accessing the administration console, including scheme, host, port and path | |
 |`keycloak_quarkus_http_relative_path` | Set the path relative to / for serving resources. The path must start with a / | `/` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -39,7 +39,12 @@ keycloak_quarkus_http_port: 8080
 keycloak_quarkus_https_port: 8443
 keycloak_quarkus_ajp_port: 8009
 keycloak_quarkus_jgroups_port: 7800
-keycloak_quarkus_java_opts: "-Xms1024m -Xmx2048m"
+keycloak_quarkus_java_heap_opts: "-Xms1024m -Xmx2048m"
+keycloak_quarkus_java_jvm_opts: "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8
+  -Dsun.err.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError
+  -Djava.security.egd=file:/dev/urandom -XX:+UseParallelGC -XX:GCTimeRatio=4
+  -XX:AdaptiveSizePolicyWeight=90 -XX:FlightRecorderOptions=stackdepth=512"
+keycloak_quarkus_java_opts: "{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}"
 
 ### TLS/HTTPS configuration
 keycloak_quarkus_https_key_file_enabled: false

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -156,9 +156,17 @@ argument_specs:
                 default: 7800
                 description: "jgroups cluster tcp port"
                 type: "int"
-            keycloak_quarkus_java_opts:
+            keycloak_quarkus_java_heap_opts:
                 default: "-Xms1024m -Xmx2048m"
-                description: "Additional JVM options"
+                description: "Heap memory JVM setting"
+                type: "str"
+            keycloak_quarkus_java_jvm_opts:
+                default: "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.err.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/urandom -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:FlightRecorderOptions=stackdepth=512"
+                description: "Other JVM settings"
+                type: "str"
+            keycloak_quarkus_java_opts:
+                default: "{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}"
+                description: "JVM arguments, by default heap_opts + jvm_opts, if overriden it takes precedence over them"
                 type: "str"
             keycloak_quarkus_ha_enabled:
                 default: false

--- a/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
@@ -3,4 +3,4 @@ KEYCLOAK_ADMIN={{ keycloak_quarkus_admin_user }}
 KEYCLOAK_ADMIN_PASSWORD='{{ keycloak_quarkus_admin_pass }}'
 PATH={{ keycloak_quarkus_java_home | default(keycloak_pkg_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 JAVA_HOME={{ keycloak_quarkus_java_home | default(keycloak_pkg_java_home, true) }}
-JAVA_OPTS_APPEND={{ keycloak_quarkus_java_opts }}
+JAVA_OPTS={{ keycloak_quarkus_java_opts }}


### PR DESCRIPTION
The role parameter `keycloak_quarkus_java_opts` now contains all arguments passed concatenated to the JVM, and it is used to value the `JAVA_OPTS` environment variable read be `kc.sh`. 

By dafault, it takes the contatenation of two new arguments:


| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_java_opts`| Heap memory JVM setting | `-Xms1024m -Xmx2048m` |
|`keycloak_quarkus_java_jvm_opts`| Other JVM settings | same as keycloak |
|`keycloak_quarkus_java_opts`| JVM arguments; if overriden, it takes precedence over `keycloak_quarkus_java_*` | `{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}` |

Fix #185 