### PR TITLE
Unrelax configuration file permissions

### DIFF
--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -31,7 +31,7 @@
     state: directory
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    mode: 0750
+    mode: '0750'
 
 ## check remote archive
 - name: Set download archive path
@@ -56,7 +56,7 @@
   ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
     url: "{{ keycloak_quarkus_download_url }}"
     dest: "{{ local_path.stat.path }}/{{ keycloak.bundle }}"
-    mode: 0640
+    mode: '0640'
   delegate_to: localhost
   become: false
   run_once: true
@@ -118,7 +118,7 @@
     dest: "{{ archive }}"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    mode: 0640
+    mode: '0640'
   register: new_version_downloaded
   when:
     - not archive_path.stat.exists

--- a/roles/keycloak_quarkus/tasks/jdbc_driver.yml
+++ b/roles/keycloak_quarkus/tasks/jdbc_driver.yml
@@ -6,7 +6,7 @@
     dest: "{{ keycloak.home }}/providers"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    mode: 0640
+    mode: '0640'
   become: true
   notify:
     - restart keycloak

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -27,7 +27,7 @@
     dest: "{{ keycloak.home }}/conf/keycloak.conf"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    mode: 0644
+    mode: '0640'
   become: true
   notify:
     - rebuild keycloak config
@@ -39,7 +39,7 @@
     dest: "{{ keycloak.home }}/conf/quarkus.properties"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    mode: 0644
+    mode: '0640'
   become: true
   notify:
     - restart keycloak
@@ -64,7 +64,7 @@
     dest: "{{ keycloak.home }}/conf/cache-ispn.xml"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    mode: 0644
+    mode: '0640'
   become: true
   notify:
     - rebuild keycloak config
@@ -76,7 +76,7 @@
     path:  "{{ keycloak.log.file | dirname }}"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    mode: 0775
+    mode: '0775'
   become: true
 
 - name: Flush pending handlers

--- a/roles/keycloak_quarkus/tasks/systemd.yml
+++ b/roles/keycloak_quarkus/tasks/systemd.yml
@@ -6,7 +6,7 @@
     dest: "{{ keycloak_quarkus_sysconf_file }}"
     owner: root
     group: root
-    mode: 0644
+    mode: '0640'
   vars:
     keycloak_pkg_java_home: "{{ keycloak_quarkus_pkg_java_home }}"
   notify:
@@ -18,7 +18,7 @@
     dest: /etc/systemd/system/keycloak.service
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   become: true
   register: systemdunit
   notify:


### PR DESCRIPTION
Restrict permission on some root-owned configuration files from 644 to 640