### PR TITLE
Added hostname-strict-https option

### DIFF
--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -338,6 +338,12 @@ argument_specs:
                 description: >
                   If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies
                   and we rely on the session affinity capabilities from reverse proxy
+            keycloak_quarkus_hostname_strict_https:
+                type: "bool"
+                description: >
+                  By default, Keycloak requires running using TLS/HTTPS. If the service MUST run without TLS/HTTPS, then set
+                  this option to "true"
+
     downstream:
         options:
             rhbk_version:

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -10,10 +10,10 @@ db-password={{ keycloak_quarkus_db_pass }}
 {% endif %}
 {% endif %}
 
-{% if keycloak_quarkus_hostname_strict_https and keycloak_quarkus_hostname_strict_https is sameas true -%}
+{% if keycloak_quarkus_hostname_strict_https is defined and keycloak_quarkus_hostname_strict_https is sameas true -%}
 hostname-strict-https=true
 {% endif -%}
-{% if keycloak_quarkus_hostname_strict_https and keycloak_quarkus_hostname_strict_https is sameas false -%}
+{% if keycloak_quarkus_hostname_strict_https is defined and keycloak_quarkus_hostname_strict_https is sameas false -%}
 hostname-strict-https=false
 {% endif -%}
 

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -10,6 +10,10 @@ db-password={{ keycloak_quarkus_db_pass }}
 {% endif %}
 {% endif %}
 
+{% if keycloak_quarkus_hostname_strict_https -%}
+hostname-strict-https={{ keycloak_quarkus_hostname_strict_https }}
+{% endif -%}
+
 {% if keycloak.config_key_store_enabled %}
 # Config store
 config-keystore={{ keycloak_quarkus_config_key_store_file }}

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -10,8 +10,11 @@ db-password={{ keycloak_quarkus_db_pass }}
 {% endif %}
 {% endif %}
 
-{% if keycloak_quarkus_hostname_strict_https -%}
-hostname-strict-https={{ keycloak_quarkus_hostname_strict_https }}
+{% if keycloak_quarkus_hostname_strict_https and keycloak_quarkus_hostname_strict_https is sameas true -%}
+hostname-strict-https=true
+{% endif -%}
+{% if keycloak_quarkus_hostname_strict_https and keycloak_quarkus_hostname_strict_https is sameas false -%}
+hostname-strict-https=false
 {% endif -%}
 
 {% if keycloak.config_key_store_enabled %}


### PR DESCRIPTION
Resolves #193 

Added a new option `keycloak_quarkus_hostname_strict_https` with no default value.

If the option is set, the Jinja template for `keycloak.conf.j2` checks to see if the value is either `true` or `false` and applies it appropriately