### PR TITLE
Keystore based vault SPI

### DIFF
--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -1,16 +1,20 @@
 ---
 - name: Converge
   hosts: all
-  vars: 
+  vars:
     keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_admin_password: "remembertochangeme"
     keycloak_realm: TestRealm
     keycloak_quarkus_host: instance
     keycloak_quarkus_log: file
-    keycloak_quarkus_https_key_file_enabled: True
+    keycloak_quarkus_log_level: debug
+    keycloak_quarkus_https_key_file_enabled: true
     keycloak_quarkus_key_file: "/opt/keycloak/certs/key.pem"
     keycloak_quarkus_cert_file: "/opt/keycloak/certs/cert.pem"
     keycloak_quarkus_log_target: /tmp/keycloak
+    keycloak_quarkus_ks_vault_enabled: true
+    keycloak_quarkus_ks_vault_file: "/opt/keycloak/certs/keystore.p12"
+    keycloak_quarkus_ks_vault_pass: keystorepassword
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm

--- a/molecule/quarkus/prepare.yml
+++ b/molecule/quarkus/prepare.yml
@@ -21,7 +21,12 @@
         path: "/opt/keycloak/certs/"
         mode: 0755
 
-    - name: Copy certificates
+    - name: Create vault keystore
+      ansible.builtin.command: keytool -importpass -alias TestRealm_testalias -keystore keystore.p12 -storepass keystorepassword
+      delegate_to: localhost
+      changed_when: False
+
+    - name: Copy certificates and vault
       become: yes
       ansible.builtin.copy:
         src: "{{ item }}"
@@ -30,3 +35,4 @@
       loop:
         - cert.pem
         - key.pem
+        - keystore.p12

--- a/molecule/quarkus/verify.yml
+++ b/molecule/quarkus/verify.yml
@@ -76,13 +76,10 @@
         that:
           - not keycloak_default_log_folder.stat.exists
 
-    - name: Read content of logs
-      ansible.builtin.slurp:
-        src: /tmp/keycloak/keycloak.log
+    - name: Verify vault SPI in logfile
+      ansible.builtin.shell: |
+        set -o pipefail
+        zgrep 'Configured KeystoreVaultProviderFactory with the keystore file' /opt/keycloak/keycloak-*/data/log/keycloak.log*zip
+      changed_when: false
+      failed_when: slurped_log.rc != 0
       register: slurped_log
-
-    - name: Verify keystore vault loaded
-      ansible.builtin.assert:
-        that:
-          - "'Configured KeystoreVaultProviderFactory with the keystore file' in slurped_log.content | b64decode"
-        fail_msg: "Service failed to use keystore vault correctly"

--- a/molecule/quarkus/verify.yml
+++ b/molecule/quarkus/verify.yml
@@ -10,6 +10,7 @@
         that:
           - ansible_facts.services["keycloak.service"]["state"] == "running"
           - ansible_facts.services["keycloak.service"]["status"] == "enabled"
+        fail_msg: "Service not running"
 
     - name: Set internal envvar
       ansible.builtin.set_fact:
@@ -40,7 +41,7 @@
 
     - name: Check log folder
       ansible.builtin.stat:
-        path: "/tmp/keycloak"
+        path: /tmp/keycloak
       register: keycloak_log_folder
 
     - name: Check that keycloak log folder exists and is a link
@@ -49,11 +50,12 @@
           - keycloak_log_folder.stat.exists
           - not keycloak_log_folder.stat.isdir
           - keycloak_log_folder.stat.islnk
+        fail_msg: "Service log symlink not correctly created"
 
     - name: Check log file
       become: yes
       ansible.builtin.stat:
-        path: "/tmp/keycloak/keycloak.log"
+        path: /tmp/keycloak/keycloak.log
       register: keycloak_log_file
 
     - name: Check if keycloak file exists
@@ -65,7 +67,7 @@
     - name: Check default log folder
       become: yes
       ansible.builtin.stat:
-        path: "/var/log/keycloak"
+        path: /var/log/keycloak
       register: keycloak_default_log_folder
       failed_when: false
 
@@ -73,3 +75,14 @@
       ansible.builtin.assert:
         that:
           - not keycloak_default_log_folder.stat.exists
+
+    - name: Read content of logs
+      ansible.builtin.slurp:
+        src: /tmp/keycloak/keycloak.log
+      register: slurped_log
+
+    - name: Verify keystore vault loaded
+      ansible.builtin.assert:
+        that:
+          - "'Configured KeystoreVaultProviderFactory with the keystore file' in slurped_log.content | b64decode"
+        fail_msg: "Service failed to use keystore vault correctly"

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -7,14 +7,14 @@ Install [keycloak](https://keycloak.org/) >= 20.0.0 (quarkus) server configurati
 Role Defaults
 -------------
 
-* Installation options
+#### Installation options
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
 |`keycloak_quarkus_version`| keycloak.org package version | `24.0.3` |
 
 
-* Service configuration
+#### Service configuration
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
@@ -61,7 +61,7 @@ Role Defaults
 |`keycloak_quarkus_config_key_store_password`| Password of the configuration key store; if non-empty, `keycloak_quarkus_db_pass` will be saved to the key store at `keycloak_quarkus_config_key_store_file` (instead of being written to the configuration file in clear text | `""` |
 
 
-* Hostname configuration
+#### Hostname configuration
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
@@ -70,7 +70,7 @@ Role Defaults
 |`keycloak_quarkus_hostname_strict_backchannel`| By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. If all applications use the public URL this option should be enabled. | `false` |
 
 
-* Database configuration
+#### Database configuration
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
@@ -81,7 +81,7 @@ Role Defaults
 |`keycloak_quarkus_jdbc_driver_version` | Version for JDBC driver | `9.4.1212` |
 
 
-* Remote caches configuration
+#### Remote caches configuration
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
@@ -94,7 +94,7 @@ Role Defaults
 |`keycloak_quarkus_ispn_trust_store_password` | Password for infinispan certificate keystore | `changeit` |
 
 
-* Install options
+#### Install options
 
 | Variable | Description | Default |
 |:---------|:------------|:---------|
@@ -105,7 +105,7 @@ Role Defaults
 |`keycloak_quarkus_configure_firewalld` | Ensure firewalld is running and configure keycloak ports | `False` |
 
 
-* Miscellaneous configuration
+#### Miscellaneous configuration
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
@@ -132,6 +132,16 @@ Role Defaults
 |`keycloak_quarkus_transaction_xa_enabled`| Whether to use XA transactions | `True` |
 |`keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route`| If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies and we rely on the session affinity capabilities from reverse proxy | `True` |
 
+
+#### Vault SPI
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`keycloak_quarkus_ks_vault_enabled`| Whether to enable the vault SPI | `false` |
+|`keycloak_quarkus_ks_vault_file`| The keystore path for the vault SPI | `{{ keycloak_quarkus_config_dir }}/keystore.p12` |
+|`keycloak_quarkus_ks_vault_type`| Type of the keystore used for the vault SPI | `PKCS12` |
+
+
 Role Variables
 --------------
 
@@ -140,6 +150,7 @@ Role Variables
 |`keycloak_quarkus_admin_pass`| Password of console admin account | `yes` |
 |`keycloak_quarkus_frontend_url`| Base URL for frontend URLs, including scheme, host, port and path | `no` |
 |`keycloak_quarkus_admin_url`| Base URL for accessing the administration console, including scheme, host, port and path | `no` |
+|`keycloak_quarkus_ks_vault_pass`| The password for accessing the keystore vault SPI | `no` |
 
 
 License

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -135,3 +135,9 @@ keycloak_quarkus_log_target: /var/log/keycloak
 keycloak_quarkus_log_max_file_size: 10M
 keycloak_quarkus_log_max_backup_index: 10
 keycloak_quarkus_log_file_suffix: '.yyyy-MM-dd.zip'
+
+# keystore-based vault
+keycloak_quarkus_ks_vault_enabled: false
+keycloak_quarkus_ks_vault_file: "{{ keycloak_quarkus_config_dir }}/keystore.p12"
+keycloak_quarkus_ks_vault_type: PKCS12
+keycloak_quarkus_ks_vault_pass:

--- a/roles/keycloak_quarkus/handlers/main.yml
+++ b/roles/keycloak_quarkus/handlers/main.yml
@@ -3,11 +3,13 @@
 - name: "Rebuild {{ keycloak.service_name }} config"
   ansible.builtin.include_tasks: rebuild_config.yml
   listen: "rebuild keycloak config"
+
 - name: "Restart {{ keycloak.service_name }}"
   ansible.builtin.include_tasks: restart.yml
   listen: "restart keycloak"
+
 - name: "Print deprecation warning"
   ansible.builtin.fail:
     msg: "Deprecation warning: you are using the deprecated variable '{{ deprecated_variable | d('NotSet') }}', check docs on how to upgrade."
-  ignore_errors: True
+  ignore_errors: true
   listen: "print deprecation warning"

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -338,6 +338,22 @@ argument_specs:
                 description: >
                   If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies
                   and we rely on the session affinity capabilities from reverse proxy
+            keycloak_quarkus_ks_vault_enabled:
+                default: false
+                type: "bool"
+                description: "Whether to enable vault SPI"
+            keycloak_quarkus_ks_vault_file:
+                default: "{{ keycloak_quarkus_config_dir }}/keystore.p12"
+                type: "str"
+                description: "The keystore path for the vault SPI"
+            keycloak_quarkus_ks_vault_type:
+                default: "PKCS12"
+                type: "str"
+                description: "Type of the keystore used for the vault SPI"
+            keycloak_quarkus_ks_vault_pass:
+                required: false
+                type: "str"
+                description: "The password for accessing the keystore vault SPI"
     downstream:
         options:
             rhbk_version:

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -82,3 +82,11 @@ log={{ keycloak_quarkus_log }}
 log-level={{ keycloak.log.level }}
 log-file={{ keycloak.log.file }}
 log-file-format={{ keycloak.log.format }}
+
+# Vault
+{% if keycloak_quarkus_ks_vault_enabled %}
+vault=keystore
+vault-file={{ keycloak_quarkus_ks_vault_file }}
+vault-type={{ keycloak_quarkus_ks_vault_type }}
+vault-pass={{ keycloak_quarkus_ks_vault_pass }}
+{% endif %}


### PR DESCRIPTION
Add parameters that allow to configure keystore-based vault SPI:

Role Defaults
-------------
| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_ks_vault_enabled`| Whether to enable the vault SPI | `false` |
|`keycloak_quarkus_ks_vault_file`| The keystore path for the vault SPI | `{{ keycloak_quarkus_config_dir }}/keystore.p12` |
|`keycloak_quarkus_ks_vault_type`| Type of the keystore used for the vault SPI | `PKCS12` |

Role Variables
--------------

| Variable | Description | Required |
|:---------|:------------|----------|
|`keycloak_quarkus_ks_vault_pass`| The password for accessing the keystore vault SPI | `no` |


See: https://www.keycloak.org/server/vault#_configuring_the_java_keystore_based_vault
Also see molecule/quarkus/converge.yml for usage

Fix #172 