### PR TITLE
#190: remove `keycloak_quarkus_admin_user[_pass]` once keycloak is bootstrapped

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -152,6 +152,14 @@ Role Variables
 |`keycloak_quarkus_admin_url`| Base URL for accessing the administration console, including scheme, host, port and path | `no` |
 |`keycloak_quarkus_ks_vault_pass`| The password for accessing the keystore vault SPI | `no` |
 
+Role custom facts
+-----------------
+
+The role uses the following [custom facts](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html#adding-custom-facts) found in `/etc/ansible/facts.d/keycloak.fact` (and thus identified by the `ansible_local.keycloak.` prefix):
+
+| Variable | Description |
+|:---------|:------------|
+|`general.bootstrapped` | A custom fact indicating whether this role has been used for bootstrapping keycloak on the respective host before; set to `false` (e.g., when starting off with a new, empty database) ensures that the initial admin user as defined by `keycloak_quarkus_admin_user[_pass]` gets created |
 
 License
 -------

--- a/roles/keycloak_quarkus/handlers/main.yml
+++ b/roles/keycloak_quarkus/handlers/main.yml
@@ -3,7 +3,9 @@
 - name: "Rebuild {{ keycloak.service_name }} config"
   ansible.builtin.include_tasks: rebuild_config.yml
   listen: "rebuild keycloak config"
-
+- name: "Bootstrapped"
+  ansible.builtin.include_tasks: bootstrapped.yml
+  listen: bootstrapped
 - name: "Restart {{ keycloak.service_name }}"
   ansible.builtin.include_tasks: restart.yml
   listen: "restart keycloak"

--- a/roles/keycloak_quarkus/tasks/bootstrapped.yml
+++ b/roles/keycloak_quarkus/tasks/bootstrapped.yml
@@ -1,0 +1,16 @@
+---
+- name: Write ansible custom facts
+  become: true
+  ansible.builtin.template:
+    src: keycloak.fact.j2
+    dest: /etc/ansible/facts.d/keycloak.fact
+    mode: '0644'
+  vars:
+    bootstrapped: true
+
+- name: Re-read custom facts
+  ansible.builtin.setup:
+    filter: ansible_local
+
+- name: Ensure that `KEYCLOAK_ADMIN[_PASSWORD]` get purged
+  ansible.builtin.include_tasks: systemd.yml

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -33,6 +33,13 @@
     group: "{{ keycloak.service_group }}"
     mode: '0750'
 
+- name: Create directory for ansible custom facts
+  become: true
+  ansible.builtin.file:
+    state: directory
+    recurse: true
+    path: /etc/ansible/facts.d
+
 ## check remote archive
 - name: Set download archive path
   ansible.builtin.set_fact:

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -96,11 +96,6 @@
 - name: "Start and wait for keycloak service"
   ansible.builtin.include_tasks: start.yml
 
-- name: Check service status
-  ansible.builtin.command: "systemctl status keycloak"
-  register: keycloak_service_status
-  changed_when: false
-
 - name: Link default logs directory
   ansible.builtin.file:
     state: link
@@ -108,3 +103,21 @@
     dest: "{{ keycloak_quarkus_log_target }}"
     force: true
   become: true
+
+- name: Check service status
+  ansible.builtin.systemd_service:
+    name: "{{ keycloak.service_name }}"
+  register: keycloak_service_status
+  changed_when: false
+
+- name: "Trigger bootstrapped notification: remove `keycloak_quarkus_admin_user[_pass]` env vars"
+  when:
+    - not ansible_local.keycloak.general.bootstrapped | default(false) | bool # it was not bootstrapped prior to the current role's execution
+    - keycloak_service_status.status.ActiveState == "active"                  # but it is now
+  ansible.builtin.assert: { that: true, quiet: true }
+  changed_when: true
+  notify:
+    - bootstrapped
+
+- name: Flush pending handlers
+  ansible.builtin.meta: flush_handlers

--- a/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
@@ -1,6 +1,10 @@
 {{ ansible_managed | comment }}
+{% if not ansible_local.keycloak.general.bootstrapped | default(false) | bool %}
 KEYCLOAK_ADMIN={{ keycloak_quarkus_admin_user }}
 KEYCLOAK_ADMIN_PASSWORD='{{ keycloak_quarkus_admin_pass }}'
+{% else %}
+{{ keycloak.bootstrap_mnemonic }}
+{% endif %}
 PATH={{ keycloak_quarkus_java_home | default(keycloak_sys_pkg_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 JAVA_HOME={{ keycloak_quarkus_java_home | default(keycloak_sys_pkg_java_home, true) }}
 JAVA_OPTS={{ keycloak_quarkus_java_opts }}

--- a/roles/keycloak_quarkus/templates/keycloak.fact.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.fact.j2
@@ -1,0 +1,2 @@
+[general]
+bootstrapped={{ bootstrapped | lower }}

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -15,3 +15,4 @@ keycloak: # noqa var-naming this is an internal dict of interpolated values
     file: "{{ keycloak_quarkus_home }}/{{ keycloak_quarkus_log_file }}"
     level: "{{ keycloak_quarkus_log_level }}"
     format: "{{ keycloak_quarkus_log_format }}"
+  bootstrap_mnemonic: "# ansible-middleware/keycloak: bootstrapped"


### PR DESCRIPTION
@guidograzioli this is my take on #190:
This approach could be troublesome when the state file (`/etc/sysconfig/keycloak`) contains the bootstrapped mnemonicer already, but we are switching DBs where the new DB is completely empty.
But I guess this edge case would be ok favoring hiding these sensitive credentials on the long term, worst case one needs to set `keycloak_quarkus_purge_admin_credentials_after_bootstrapping=True` and then run the playbook once more.

Wdyt?