### PR TITLE
Providers config and custom providers

### DIFF
--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -19,6 +19,16 @@
     keycloak_quarkus_systemd_wait_for_timeout: 20
     keycloak_quarkus_systemd_wait_for_delay: 2
     keycloak_quarkus_systemd_wait_for_log: true
+    keycloak_quarkus_providers:
+      - id: http-client
+        spi: connections
+        default: true
+        restart: true
+        properties:
+          - key: default-connection-pool-size
+            value: 10
+      - id: spid-saml
+        url: https://github.com/italia/spid-keycloak-provider/releases/download/24.0.2/spid-provider.jar
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -145,6 +145,33 @@ Role Defaults
 |`keycloak_quarkus_ks_vault_type`| Type of the keystore used for the vault SPI | `PKCS12` |
 
 
+#### Configuring providers
+
+| Variable | Description | Default |
+|:---------|:------------|:--------|
+|`keycloak_quarkus_providers`| List of provider definitions; see below | `[]` |
+
+Provider definition:
+
+```yaml
+keycloak_quarkus_providers:
+  - id: http-client                         # required
+    spi: connections                        # required if url is not specified
+    default: true                           # optional, whether to set default for spi, default false
+    restart: true                           # optional, whether to restart, default true
+    url: https://.../.../custom_spi.jar     # optional, url for download
+    properties:                             # optional, list of key-values
+      - key: default-connection-pool-size
+        value: 10
+```
+
+the definition above will generate the following build command:
+
+```
+bin/kc.sh build --spi-connections-provider=http-client --spi-connections-http-client-default-connection-pool-size=10
+```
+
+
 Role Variables
 --------------
 

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -144,3 +144,5 @@ keycloak_quarkus_ks_vault_enabled: false
 keycloak_quarkus_ks_vault_file: "{{ keycloak_quarkus_config_dir }}/keystore.p12"
 keycloak_quarkus_ks_vault_type: PKCS12
 keycloak_quarkus_ks_vault_pass:
+
+keycloak_quarkus_providers: []

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -372,6 +372,10 @@ argument_specs:
                 description: "Activation delay for service systemd unit (seconds)"
                 default: 10
                 type: 'int'
+            keycloak_quarkus_providers:
+                description: "List of provider definition dicts: { 'id': str, 'spi': str, 'url': str, 'default': bool, 'properties': list of key/value }"
+                default: []
+                type: "list"
     downstream:
         options:
             rhbk_version:

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -164,3 +164,15 @@
   when:
     - rhbk_enable is defined and rhbk_enable
     - keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url is defined
+
+- name: "Download custom providers"
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"
+    owner: "{{ keycloak.service_user }}"
+    group: "{{ keycloak.service_group }}"
+    mode: '0640'
+  become: true
+  loop: "{{ keycloak_quarkus_providers }}"
+  when: item.url is defined and item.url | length > 0
+  notify: "{{ ['rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or not item.restart else [] }}"

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -56,3 +56,12 @@
       when: keytool_check.rc != 0
       ansible.builtin.fail:
         msg: "keytool NOT found in the PATH, but is required for setting up the configuration key store"
+
+- name: "Validate providers"
+  ansible.builtin.assert:
+    that:
+      - item.id is defined and item.id | length > 0
+      - (item.spi is defined and item.spi | length > 0) or (item.url is defined and item.url | length > 0)
+    quiet: true
+    fail_msg: "Providers definition is incorrect; `id` and one of `spi` or `url` are mandatory. `key` and `value` are mandatory for each property"
+  loop: "{{ keycloak_quarkus_providers }}"

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -97,3 +97,14 @@ vault-file={{ keycloak_quarkus_ks_vault_file }}
 vault-type={{ keycloak_quarkus_ks_vault_type }}
 vault-pass={{ keycloak_quarkus_ks_vault_pass }}
 {% endif %}
+
+
+# Providers
+{% for provider in keycloak_quarkus_providers %}
+{% if provider.default is defined and provider.default %}
+spi-{{ provider.spi }}-provider={{ provider.id }}
+{% endif %}
+{% if provider.properties is defined %}{% for property in provider.properties %}
+spi-{{ provider.spi }}-{{ provider.id }}-{{ property.key }}={{ property.value }}
+{% endfor %}{% endif %}
+{% endfor %}


### PR DESCRIPTION
#### Configuring providers

| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_providers`| List of provider definitions; see below | `[]` |

Provider definition:

```yaml
keycloak_quarkus_providers:
  - id: http-client                         # required
    spi: connections                        # required if url is not specified
    default: true                           # optional, whether to set default for spi, default false
    restart: true                           # optional, whether to restart, default true
    url: https://.../.../custom_spi.jar     # optional, url for download
    properties:                             # optional, list of key-values
      - key: default-connection-pool-size
        value: 10
```

the definition above will generate the same configuration as the following build command:

```
bin/kc.sh build --spi-connections-provider=http-client --spi-connections-http-client-default-connection-pool-size=10
```

Fix #131 