### PR TITLE
Customize jdbc driver downloads, optional authentication

### DIFF
--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -372,6 +372,15 @@ argument_specs:
                 description: "Activation delay for service systemd unit (seconds)"
                 default: 10
                 type: 'int'
+            keycloak_quarkus_jdbc_download_url:
+                description: "Override the default Maven Central download URL for the JDBC driver"
+                type: "str"
+            keycloak_quarkus_jdbc_download_user:
+                description: "Set a username with which to authenticate when downloading JDBC drivers from an alternative location"
+                type: "str"
+            keycloak_quarkus_jdbc_download_pass:
+                description: "Set a password with which to authenticate when downloading JDBC drivers from an alternative location (requires keycloak_quarkus_jdbc_download_user)"
+                type: "str"
     downstream:
         options:
             rhbk_version:

--- a/roles/keycloak_quarkus/tasks/jdbc_driver.yml
+++ b/roles/keycloak_quarkus/tasks/jdbc_driver.yml
@@ -1,6 +1,6 @@
 ---
-- name: Verify valid parameters for download credentials when specified
-  fail:
+- name: "Verify valid parameters for download credentials when specified"
+  ansible.builtin.fail:
     msg: >-
       When JDBC driver download credentials are set, both the username and the password MUST be set
     when:

--- a/roles/keycloak_quarkus/tasks/jdbc_driver.yml
+++ b/roles/keycloak_quarkus/tasks/jdbc_driver.yml
@@ -1,10 +1,19 @@
 ---
-- name: "Retrieve JDBC Driver from {{ keycloak_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url }}"
+- name: Verify valid parameters for download credentials when specified
+  fail:
+    msg: >-
+      When JDBC driver download credentials are set, both the username and the password MUST be set
+    when:
+      - keycloak_jdbc_download_user is undefined and keycloak_jdbc_download_pass is not undefined
+      - keycloak_jdbc_download_pass is undefined and keycloak_jdbc_download_user is not undefined
+- name: "Retrieve JDBC Driver from {{ keycloak_jdbc_download_user | default(keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url) }}"
   ansible.builtin.get_url:
-    url: "{{ keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url }}"
+    url: "{{ keycloak_jdbc_download_url | default(keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url) }}"
     dest: "{{ keycloak.home }}/providers"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
+    url_username: "{{ keycloak_jdbc_download_user | default(omit) }}"
+    url_password: "{{ keycloak_jdbc_download_pass | default(omit) }}"
     mode: '0640'
   become: true
   notify:


### PR DESCRIPTION
Add three new parameters which allow for overriding the download URL for the JDBC driver and also specifying credentials for downloading those JDBC drivers.

| Variable | Description | Required |
|:---------|:------------|:---------|
|`keycloak_quarkus_jdbc_download_url`| Override the default Maven Central download URL for the JDBC driver | `no` |
|`keycloak_quarkus_jdbc_download_user`| Set a username with which to authenticate when downloading JDBC drivers from an alternative location | `no` |
|`keycloak_quarkus_jdbc_download_pass`| Set a password with which to authenticate when downloading JDBC drivers from an alternative location (requires keycloak_quarkus_jdbc_download_user) | `no` |


Resolves #200 