### PR TITLE
jdbc_download and validate_certs params update

### DIFF
--- a/roles/keycloak/meta/argument_specs.yml
+++ b/roles/keycloak/meta/argument_specs.yml
@@ -316,6 +316,19 @@ argument_specs:
                 default: '/var/log/keycloak'
                 type: "str"
                 description: "Set the destination of the keycloak log folder link"
+            keycloak_jdbc_download_url:
+                description: "Override the default Maven Central download URL for the JDBC driver"
+                type: "str"
+            keycloak_jdbc_download_user:
+                description: "Set a username with which to authenticate when downloading JDBC drivers from an alternative location"
+                type: "str"
+            keycloak_jdbc_download_pass:
+                description: "Set a password with which to authenticate when downloading JDBC drivers from an alternative location (requires keycloak_jdbc_download_user)"
+                type: "str"
+            keycloak_jdbc_download_validate_certs:
+                default: true
+                description: "Allow the option to ignore invalid certificates when downloading JDBC drivers from a custom URL"
+                type: "bool"
     downstream:
         options:
             sso_version:

--- a/roles/keycloak/tasks/jdbc_driver.yml
+++ b/roles/keycloak/tasks/jdbc_driver.yml
@@ -16,6 +16,12 @@
   become: true
   when:
     - not dest_path.stat.exists
+- name: "Verify valid parameters for download credentials when specified"
+  ansible.builtin.fail:
+    msg: >-
+      When JDBC driver download credentials are set, both the username and the password MUST be set
+  when:
+    - (keycloak_jdbc_download_user is undefined and keycloak_jdbc_download_pass is not undefined) or (keycloak_jdbc_download_pass is undefined and keycloak_jdbc_download_user is not undefined)
 
 - name: "Retrieve JDBC Driver from {{ keycloak_jdbc[keycloak_jdbc_engine].driver_jar_url }}"
   ansible.builtin.get_url:
@@ -23,6 +29,9 @@
     dest: "{{ keycloak_jdbc[keycloak_jdbc_engine].driver_module_dir }}/{{ keycloak_jdbc[keycloak_jdbc_engine].driver_jar_filename }}"
     group: "{{ keycloak_service_group }}"
     owner: "{{ keycloak_service_user }}"
+    url_username: "{{ keycloak_jdbc_download_user | default(omit) }}"
+    url_password: "{{ keycloak_jdbc_download_pass | default(omit) }}"
+    validate_certs: "{{ keycloak_jdbc_download_validate_certs | default(omit) }}"
     mode: 0640
   become: true
 

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -385,6 +385,10 @@ argument_specs:
             keycloak_quarkus_jdbc_download_pass:
                 description: "Set a password with which to authenticate when downloading JDBC drivers from an alternative location (requires keycloak_quarkus_jdbc_download_user)"
                 type: "str"
+            keycloak_quarkus_jdbc_download_validate_certs:
+                default: true
+                description: "Allow the option to ignore invalid certificates when downloading JDBC drivers from a custom URL"
+                type: "bool"
     downstream:
         options:
             rhbk_version:

--- a/roles/keycloak_quarkus/tasks/jdbc_driver.yml
+++ b/roles/keycloak_quarkus/tasks/jdbc_driver.yml
@@ -4,15 +4,16 @@
     msg: >-
       When JDBC driver download credentials are set, both the username and the password MUST be set
   when:
-    - (keycloak_jdbc_download_user is undefined and keycloak_jdbc_download_pass is not undefined) or (keycloak_jdbc_download_pass is undefined and keycloak_jdbc_download_user is not undefined)
+    - (keycloak_quarkus_jdbc_download_user is undefined and keycloak_quarkus_jdbc_download_pass is not undefined) or (keycloak_quarkus_jdbc_download_pass is undefined and keycloak_quarkus_jdbc_download_user is not undefined)
 - name: "Retrieve JDBC Driver from {{ keycloak_jdbc_download_user | default(keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url) }}"
   ansible.builtin.get_url:
-    url: "{{ keycloak_jdbc_download_url | default(keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url) }}"
+    url: "{{ keycloak_quarkus_jdbc_download_url | default(keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url) }}"
     dest: "{{ keycloak.home }}/providers"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
-    url_username: "{{ keycloak_jdbc_download_user | default(omit) }}"
-    url_password: "{{ keycloak_jdbc_download_pass | default(omit) }}"
+    url_username: "{{ keycloak_quarkus_jdbc_download_user | default(omit) }}"
+    url_password: "{{ keycloak_quarkus_jdbc_download_pass | default(omit) }}"
+    validate_certs: "{{ keycloak_quarkus_jdbc_download_validate_certs | default(omit) }}"
     mode: '0640'
   become: true
   notify:


### PR DESCRIPTION
- Added jdbc_download customization to both keycloak releases
- Added option to allow invalid certificates to download JDBC drivers

Resolves #206 

I was able to test for keycloak_quarkus, but not for keycloak.