### PR TITLE
Enable copying of key material

### DIFF
--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -10,7 +10,7 @@
     keycloak_quarkus_log_level: debug
     keycloak_quarkus_https_key_file_enabled: true
     keycloak_quarkus_key_file_copy_enabled: true
-    keycloak_quarkus_key_file_src: key.pem
+    keycloak_quarkus_key_content: "{{ lookup('file', 'key.pem') }}"
     keycloak_quarkus_cert_file_copy_enabled: true
     keycloak_quarkus_cert_file_src: cert.pem
     keycloak_quarkus_log_target: /tmp/keycloak

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -9,11 +9,13 @@
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: debug
     keycloak_quarkus_https_key_file_enabled: true
-    keycloak_quarkus_key_file: "/opt/keycloak/certs/key.pem"
-    keycloak_quarkus_cert_file: "/opt/keycloak/certs/cert.pem"
+    keycloak_quarkus_key_file_copy_enabled: true
+    keycloak_quarkus_key_file_src: key.pem
+    keycloak_quarkus_cert_file_copy_enabled: true
+    keycloak_quarkus_cert_file_src: cert.pem
     keycloak_quarkus_log_target: /tmp/keycloak
     keycloak_quarkus_ks_vault_enabled: true
-    keycloak_quarkus_ks_vault_file: "/opt/keycloak/certs/keystore.p12"
+    keycloak_quarkus_ks_vault_file: "/opt/keycloak/vault/keystore.p12"
     keycloak_quarkus_ks_vault_pass: keystorepassword
     keycloak_quarkus_systemd_wait_for_port: true
     keycloak_quarkus_systemd_wait_for_timeout: 20

--- a/molecule/quarkus/prepare.yml
+++ b/molecule/quarkus/prepare.yml
@@ -14,11 +14,11 @@
       delegate_to: localhost
       changed_when: False
 
-    - name: Create conf directory # risky-file-permissions in test user account does not exist yet
+    - name: Create vault directory
       become: true
       ansible.builtin.file:
         state: directory
-        path: "/opt/keycloak/certs/"
+        path: "/opt/keycloak/vault"
         mode: 0755
 
     - name: Make sure a jre is available (for keytool to prepare keystore)
@@ -39,10 +39,6 @@
     - name: Copy certificates and vault
       become: true
       ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: "/opt/keycloak/certs/{{ item }}"
+        src: keystore.p12
+        dest: /opt/keycloak/vault/keystore.p12
         mode: 0444
-      loop:
-        - cert.pem
-        - key.pem
-        - keystore.p12

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -45,7 +45,7 @@ Role Defaults
 |`keycloak_quarkus_http_enabled`| Enable listener on HTTP port | `True` |
 |`keycloak_quarkus_https_key_file_enabled`| Enable listener on HTTPS port | `False` |
 |`keycloak_quarkus_key_file_copy_enabled`| Enable copy of key file to target host | `False` |
-|`keycloak_quarkus_key_file_src`| Set the source file path | `""` |
+|`keycloak_quarkus_key_content`| Content of the TLS private key. Use `"{{ lookup('file', 'server.key.pem') }}"` to lookup a file. | `""` |
 |`keycloak_quarkus_key_file`| The file path to a private key in PEM format | `/etc/pki/tls/private/server.key.pem` |
 |`keycloak_quarkus_cert_file_copy_enabled`| Enable copy of cert file to target host | `False`|
 |`keycloak_quarkus_cert_file_src`| Set the source file path | `""` |

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -44,8 +44,12 @@ Role Defaults
 |`keycloak_quarkus_http_relative_path` | Set the path relative to / for serving resources. The path must start with a / | `/` |
 |`keycloak_quarkus_http_enabled`| Enable listener on HTTP port | `True` |
 |`keycloak_quarkus_https_key_file_enabled`| Enable listener on HTTPS port | `False` |
-|`keycloak_quarkus_key_file`| The file path to a private key in PEM format | `{{ keycloak.home }}/conf/server.key.pem` |
-|`keycloak_quarkus_cert_file`| The file path to a server certificate or certificate chain in PEM format | `{{ keycloak.home }}/conf/server.crt.pem` |
+|`keycloak_quarkus_key_file_copy_enabled`| Enable copy of key file to target host | `False` |
+|`keycloak_quarkus_key_file_src`| Set the source file path | `""` |
+|`keycloak_quarkus_key_file`| The file path to a private key in PEM format | `/etc/pki/tls/private/server.key.pem` |
+|`keycloak_quarkus_cert_file_copy_enabled`| Enable copy of cert file to target host | `False`|
+|`keycloak_quarkus_cert_file_src`| Set the source file path | `""` |
+|`keycloak_quarkus_cert_file`| The file path to a server certificate or certificate chain in PEM format | `/etc/pki/tls/certs/server.crt.pem` |
 |`keycloak_quarkus_https_key_store_enabled`| Enable configuration of HTTPS via a key store | `False` |
 |`keycloak_quarkus_key_store_file`| Deprecated, use `keycloak_quarkus_https_key_store_file` instead. ||
 |`keycloak_quarkus_key_store_password`| Deprecated, use `keycloak_quarkus_https_key_store_password` instead.||

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -48,7 +48,7 @@ keycloak_quarkus_java_opts: "{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak
 ### TLS/HTTPS configuration
 keycloak_quarkus_https_key_file_enabled: false
 keycloak_quarkus_key_file_copy_enabled: false
-keycloak_quarkus_key_file_src: ""
+keycloak_quarkus_key_content: ""
 keycloak_quarkus_key_file: "/etc/pki/tls/private/server.key.pem"
 keycloak_quarkus_cert_file_copy_enabled: false
 keycloak_quarkus_cert_file_src: ""

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -47,8 +47,12 @@ keycloak_quarkus_java_opts: "{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak
 
 ### TLS/HTTPS configuration
 keycloak_quarkus_https_key_file_enabled: false
-keycloak_quarkus_key_file: "{{ keycloak.home }}/conf/server.key.pem"
-keycloak_quarkus_cert_file: "{{ keycloak.home }}/conf/server.crt.pem"
+keycloak_quarkus_key_file_copy_enabled: false
+keycloak_quarkus_key_file_src: ""
+keycloak_quarkus_key_file: "/etc/pki/tls/private/server.key.pem"
+keycloak_quarkus_cert_file_copy_enabled: false
+keycloak_quarkus_cert_file_src: ""
+keycloak_quarkus_cert_file: "/etc/pki/tls/certs/server.crt.pem"
 #### key store configuration
 keycloak_quarkus_https_key_store_enabled: false
 keycloak_quarkus_https_key_store_file: "{{ keycloak.home }}/conf/key_store.p12"

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -108,12 +108,28 @@ argument_specs:
                 default: false
                 description: "Enable configuration of HTTPS via files in PEM format"
                 type: "bool"
+            keycloak_quarkus_key_file_copy_enabled:
+                default: false
+                description: "Enable copy of key file to target host"
+                type: "bool"
+            keycloak_quarkus_key_file_src:
+                default: ""
+                description: "Set the source file path"
+                type: "str"
             keycloak_quarkus_key_file:
-                default: "{{ keycloak.home }}/conf/server.key.pem"
+                default: "/etc/pki/tls/private/server.key.pem"
                 description: "The file path to a private key in PEM format"
                 type: "str"
+            keycloak_quarkus_cert_file_copy_enabled:
+                default: false
+                description: "Enable copy of cert file to target host"
+                type: "bool"
+            keycloak_quarkus_cert_file_src:
+                default: ""
+                description: "Set the source file path"
+                type: "str"
             keycloak_quarkus_cert_file:
-                default: "{{ keycloak.home }}/conf/server.crt.pem"
+                default: "/etc/pki/tls/certs/server.crt.pem"
                 description: "The file path to a server certificate or certificate chain in PEM format"
                 type: "str"
             keycloak_quarkus_https_key_store_enabled:

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -112,9 +112,9 @@ argument_specs:
                 default: false
                 description: "Enable copy of key file to target host"
                 type: "bool"
-            keycloak_quarkus_key_file_src:
+            keycloak_quarkus_key_content:
                 default: ""
-                description: "Set the source file path"
+                description: "Content of the TLS private key"
                 type: "str"
             keycloak_quarkus_key_file:
                 default: "/etc/pki/tls/private/server.key.pem"

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -159,6 +159,32 @@
   when:
     - (not new_version_downloaded.changed) and path_to_workdir.stat.exists
 
+- name: "Copy private key to target"
+  ansible.builtin.copy:
+    src: "{{ keycloak_quarkus_key_file_src }}"
+    dest: "{{ keycloak_quarkus_key_file }}"
+    owner: "{{ keycloak.service_user }}"
+    group: "{{ keycloak.service_group }}"
+    mode: 0640
+  become: true
+  when:
+    - keycloak_quarkus_https_key_file_enabled is defined and keycloak_quarkus_https_key_file_enabled
+    - keycloak_quarkus_key_file_copy_enabled is defined and keycloak_quarkus_key_file_copy_enabled
+    - keycloak_quarkus_key_file_src | length > 0
+
+- name: "Copy certificate to target"
+  ansible.builtin.copy:
+    src: "{{ keycloak_quarkus_cert_file_src }}"
+    dest: "{{ keycloak_quarkus_cert_file }}"
+    owner: "{{ keycloak.service_user }}"
+    group: "{{ keycloak.service_group }}"
+    mode: 0644
+  become: true
+  when:
+    - keycloak_quarkus_https_key_file_enabled is defined and keycloak_quarkus_https_key_file_enabled
+    - keycloak_quarkus_cert_file_copy_enabled is defined and keycloak_quarkus_cert_file_copy_enabled
+    - keycloak_quarkus_cert_file_src | length > 0
+
 - name: "Install {{ keycloak_quarkus_jdbc_engine }} JDBC driver"
   ansible.builtin.include_tasks: jdbc_driver.yml
   when:

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -161,7 +161,7 @@
 
 - name: "Copy private key to target"
   ansible.builtin.copy:
-    src: "{{ keycloak_quarkus_key_file_src }}"
+    content: "{{ keycloak_quarkus_key_content }}"
     dest: "{{ keycloak_quarkus_key_file }}"
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
@@ -170,7 +170,7 @@
   when:
     - keycloak_quarkus_https_key_file_enabled is defined and keycloak_quarkus_https_key_file_enabled
     - keycloak_quarkus_key_file_copy_enabled is defined and keycloak_quarkus_key_file_copy_enabled
-    - keycloak_quarkus_key_file_src | length > 0
+    - keycloak_quarkus_key_content | length > 0
 
 - name: "Copy certificate to target"
   ansible.builtin.copy:


### PR DESCRIPTION
This pull request updates the configuration to use the standard Red Hat Enterprise Linux (RHEL) default path for TLS certificates.

Also, it copies the private key and certificate to the target host.

 #208