### PR TITLE
Download from alternate URL with optional http authentication

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -185,6 +185,16 @@ Role Variables
 |`keycloak_quarkus_frontend_url`| Base URL for frontend URLs, including scheme, host, port and path | `no` |
 |`keycloak_quarkus_admin_url`| Base URL for accessing the administration console, including scheme, host, port and path | `no` |
 |`keycloak_quarkus_ks_vault_pass`| The password for accessing the keystore vault SPI | `no` |
+|`keycloak_quarkus_alternate_download_url`| Alternate location with optional authentication for downloading RHBK | `no` |
+|`keycloak_quarkus_download_user`| Optional username for http authentication  | `no*` |
+|`keycloak_quarkus_download_pass`| Optional password for http authentication | `no*` |
+|`keycloak_quarkus_download_validate_certs`| Whether to validate certs for URL `keycloak_quarkus_alternate_download_url` | `no` |
+|`keycloak_quarkus_jdbc_download_user`| Optional username for http authentication | `no*` |
+|`keycloak_quarkus_jdbc_download_pass`| Optional password for http authentication | `no*` |
+|`keycloak_quarkus_jdbc_download_validate_certs`| Whether to validate certs for URL `keycloak_quarkus_download_validate_certs` | `no` |
+
+`*` username/password authentication credentials must be both declared or both undefined
+
 
 Role custom facts
 -----------------

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -115,6 +115,25 @@
       run_once: true
       become: false
 
+- name: Perform download of RHBK from alternate download location
+  delegate_to: localhost
+  run_once: true
+  become: false
+  when:
+    - archive_path is defined
+    - archive_path.stat is defined
+    - not archive_path.stat.exists
+    - rhbk_enable is defined and rhbk_enable
+    - not keycloak.offline_install
+    - keycloak_quarkus_alternate_download_url is defined
+  ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
+    url: "{{ keycloak_quarkus_alternate_download_url }}"
+    dest: "{{ local_path.stat.path }}/{{ keycloak.bundle }}"
+    mode: '0640'
+    url_username: "{{ keycloak_quarkus_download_user | default(omit) }}"
+    url_password: "{{ keycloak_quarkus_download_pass | default(omit) }}"
+    validate_certs: "{{ keycloak_quarkus_download_validate_certs | default(omit) }}"
+
 - name: Check downloaded archive
   ansible.builtin.stat:
     path: "{{ local_path.stat.path }}/{{ keycloak.bundle }}"


### PR DESCRIPTION
| Variable | Description | Required |
|:---------|:------------|----------|
|`keycloak_quarkus_alternate_download_url`| Alternate location with optional authentication for downloading RHBK | `no` |
|`keycloak_quarkus_download_user`| Optional username for http authentication  | `no*` |
|`keycloak_quarkus_download_pass`| Optional password for http authentication | `no*` |
|`keycloak_quarkus_download_validate_certs`| Whether to validate certs for URL `keycloak_quarkus_alternate_download_url`  (if omitted, do validate) | `no` |

`*` username/password authentication credentials must be both declared or both undefined