### PR TITLE
Allow for custom providers hosted on maven repositories

### DIFF
--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -39,6 +39,8 @@
           version: 24.0.4 # optional
           # username: myUser # optional
           # password: myPAT # optional
+      # - id: my-static-theme
+      #   local_path: /tmp/my-static-theme.jar
     keycloak_quarkus_policies:
       - name: "xato-net-10-million-passwords.txt"
         url: "https://github.com/danielmiessler/SecLists/raw/master/Passwords/xato-net-10-million-passwords.txt"

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -31,6 +31,14 @@
             value: 10
       - id: spid-saml
         url: https://github.com/italia/spid-keycloak-provider/releases/download/24.0.2/spid-provider.jar
+      - id: keycloak-kerberos-federation
+        maven:
+          repository_url: https://repo1.maven.org/maven2/ # https://mvnrepository.com/artifact/org.keycloak/keycloak-kerberos-federation/24.0.4
+          group_id: org.keycloak
+          artifact_id: keycloak-kerberos-federation
+          version: 24.0.4 # optional
+          # username: myUser # optional
+          # password: myPAT # optional
     keycloak_quarkus_policies:
       - name: "xato-net-10-million-passwords.txt"
         url: "https://github.com/danielmiessler/SecLists/raw/master/Passwords/xato-net-10-million-passwords.txt"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 #################################################
-# python dependencies required to be installed 
+# python dependencies required to be installed
 # on the controller host with:
 # pip install -r requirements.txt
 #
 netaddr
+lxml # for community.general.maven_artifact

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 # pip install -r requirements.txt
 #
 netaddr
-lxml # for community.general.maven_artifact
+lxml # for middleware_automation.common.maven_artifact

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 ---
 collections:
   - name: middleware_automation.common
+    version: ">=1.2.1"
   - name: ansible.posix
-  - name: community.general # for `maven_artifact`

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,3 +2,4 @@
 collections:
   - name: middleware_automation.common
   - name: ansible.posix
+  - name: community.general # for `maven_artifact`

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -21,7 +21,6 @@ The roles depends on:
 
 * [middleware_automation.common](https://github.com/ansible-middleware/common)
 * [ansible-posix](https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
-* [community.general](https://docs.ansible.com/ansible/latest/collections/community/general/index.html)
 
 To install all the dependencies via galaxy:
 
@@ -180,9 +179,9 @@ Role Defaults
 
 Providers support different sources:
 
-* `url`: http download for SPIs not requiring authentication
-* `maven`: maven download for SPIs hosted publicly on Apache Maven Central or private Maven repositories like Github Maven requiring authentication
-* `local_path`: static SPIs to be uploaded
+* `url`: http download for providers not requiring authentication
+* `maven`: maven download for providers hosted publicly on Apache Maven Central or private Maven repositories like Github Maven requiring authentication
+* `local_path`: static providers to be uploaded
 
 Provider definition:
 

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -4,6 +4,29 @@ keycloak_quarkus
 Install [keycloak](https://keycloak.org/) >= 20.0.0 (quarkus) server configurations.
 
 
+Requirements
+------------
+
+This role requires the `python3-netaddr` and `lxml` library installed on the controller node.
+
+* to install via yum/dnf: `dnf install python3-netaddr python3-lxml`
+* to install via apt: `apt install python3-netaddr python3-lxml`
+* or via the collection: `pip install -r requirements.txt`
+
+
+Dependencies
+------------
+
+The roles depends on:
+
+* [middleware_automation.common](https://github.com/ansible-middleware/common)
+* [ansible-posix](https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
+* [community.general](https://docs.ansible.com/ansible/latest/collections/community/general/index.html)
+
+To install all the dependencies via galaxy:
+
+    ansible-galaxy collection install -r requirements.yml
+
 Role Defaults
 -------------
 
@@ -160,10 +183,17 @@ Provider definition:
 ```yaml
 keycloak_quarkus_providers:
   - id: http-client                         # required
-    spi: connections                        # required if url is not specified
+    spi: connections                        # required if neither url nor maven are specified
     default: true                           # optional, whether to set default for spi, default false
     restart: true                           # optional, whether to restart, default true
-    url: https://.../.../custom_spi.jar     # optional, url for download
+    url: https://.../.../custom_spi.jar     # optional, url for download via http
+    maven:                                  # optional, for download using maven
+      repository_url: https://maven.pkg.github.com/OWNER/REPOSITORY # optional, maven repo url
+      group_id:  my.group                   # optional, maven group id
+      artifact_id: artifact                 # optional, maven artifact id
+      version: 24.0.4                       # optional, defaults to latest
+      username:  user                       # optional, cf. https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages
+      password: pat                         # optional, provide a PAT for accessing Github's Apache Maven registry
     properties:                             # optional, list of key-values
       - key: default-connection-pool-size
         value: 10

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -178,15 +178,22 @@ Role Defaults
 |:---------|:------------|:--------|
 |`keycloak_quarkus_providers`| List of provider definitions; see below | `[]` |
 
+Providers support different sources:
+
+* `url`: http download for SPIs not requiring authentication
+* `maven`: maven download for SPIs hosted publicly on Apache Maven Central or private Maven repositories like Github Maven requiring authentication
+* `local_path`: static SPIs to be uploaded
+
 Provider definition:
 
 ```yaml
 keycloak_quarkus_providers:
-  - id: http-client                         # required
-    spi: connections                        # required if neither url nor maven are specified
+  - id: http-client                         # required; "{{ id }}.jar" identifies the file name on RHBK
+    spi: connections                        # required if neither url, local_path nor maven are specified; required for setting properties
     default: true                           # optional, whether to set default for spi, default false
     restart: true                           # optional, whether to restart, default true
     url: https://.../.../custom_spi.jar     # optional, url for download via http
+    local_path: my_theme_spi.jar            # optional, path on local controller for SPI to be uploaded
     maven:                                  # optional, for download using maven
       repository_url: https://maven.pkg.github.com/OWNER/REPOSITORY # optional, maven repo url
       group_id:  my.group                   # optional, maven group id

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -391,7 +391,7 @@ argument_specs:
                 default: 10
                 type: 'int'
             keycloak_quarkus_providers:
-                description: "List of provider definition dicts: { 'id': str, 'spi': str, 'url': str, 'default': bool, 'properties': list of key/value TODO:add maven}"
+                description: "List of provider definition dicts: { 'id': str, 'spi': str, 'url': str, 'local_path': str, 'maven': { 'repository_url': str, 'group_id': str, 'artifact_id': str, 'version': str, 'username': str, optional, 'password': str, optional }, 'default': bool, 'properties': list of key/value }"
                 default: []
                 type: "list"
             keycloak_quarkus_supported_policy_types:

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -391,7 +391,7 @@ argument_specs:
                 default: 10
                 type: 'int'
             keycloak_quarkus_providers:
-                description: "List of provider definition dicts: { 'id': str, 'spi': str, 'url': str, 'default': bool, 'properties': list of key/value }"
+                description: "List of provider definition dicts: { 'id': str, 'spi': str, 'url': str, 'default': bool, 'properties': list of key/value TODO:add maven}"
                 default: []
                 type: "list"
             keycloak_quarkus_supported_policy_types:

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -256,6 +256,17 @@
   when: item.maven is defined
   no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
 
+- name: "Upload local SPIs"
+  ansible.builtin.copy:
+    src: "{{ item.local_path}}"
+    dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"
+    owner: "{{ keycloak.service_user }}"
+    group: "{{ keycloak.service_group }}"
+    mode: '0640'
+  become: true
+  loop: "{{ keycloak_quarkus_providers }}"
+  when: item.local_path is defined
+
 - name: Ensure required folder structure for policies exists
   ansible.builtin.file:
     path: "{{ keycloak.home }}/data/{{ item | lower }}"

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -229,7 +229,7 @@
 
 # this requires the `lxml` package to be installed; we redirect this step to localhost such that we do need to install it on the remote hosts
 - name: "Download custom providers to localhost using maven"
-  community.general.maven_artifact:
+  middleware_automation.common.maven_artifact:
     repository_url: "{{ item.maven.repository_url }}"
     group_id: "{{ item.maven.group_id }}"
     artifact_id: "{{ item.maven.artifact_id }}"
@@ -244,7 +244,7 @@
   no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
   notify: "{{ ['rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or not item.restart else [] }}"
 
-- name: "Upload local maven SPIs"
+- name: "Upload local maven providers"
   ansible.builtin.copy:
     src: "{{ local_path.stat.path }}/{{ item.id }}.jar"
     dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"
@@ -256,7 +256,7 @@
   when: item.maven is defined
   no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
 
-- name: "Upload local SPIs"
+- name: "Upload local providers"
   ansible.builtin.copy:
     src: "{{ item.local_path}}"
     dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -215,7 +215,7 @@
     - rhbk_enable is defined and rhbk_enable
     - keycloak_quarkus_default_jdbc[keycloak_quarkus_jdbc_engine].driver_jar_url is defined
 
-- name: "Download custom providers"
+- name: "Download custom providers via http"
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"
@@ -227,7 +227,36 @@
   when: item.url is defined and item.url | length > 0
   notify: "{{ ['rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or not item.restart else [] }}"
 
-- name: Ensure required folder structure for policies exits
+# this requires the `lxml` package to be installed; we redirect this step to localhost such that we do need to install it on the remote hosts
+- name: "Download custom providers to localhost using maven"
+  community.general.maven_artifact:
+    repository_url: "{{ item.maven.repository_url }}"
+    group_id: "{{ item.maven.group_id }}"
+    artifact_id: "{{ item.maven.artifact_id }}"
+    version: "{{ item.maven.version | default(omit) }}"
+    username: "{{ item.maven.username | default(omit) }}"
+    password: "{{ item.maven.password | default(omit) }}"
+    dest: "{{ local_path.stat.path }}/{{ item.id }}.jar"
+  delegate_to: "localhost"
+  run_once: true
+  loop: "{{ keycloak_quarkus_providers }}"
+  when: item.maven is defined
+  no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
+  notify: "{{ ['rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or not item.restart else [] }}"
+
+- name: "Upload local maven SPIs"
+  ansible.builtin.copy:
+    src: "{{ local_path.stat.path }}/{{ item.id }}.jar"
+    dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"
+    owner: "{{ keycloak.service_user }}"
+    group: "{{ keycloak.service_group }}"
+    mode: '0640'
+  become: true
+  loop: "{{ keycloak_quarkus_providers }}"
+  when: item.maven is defined
+  no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
+
+- name: Ensure required folder structure for policies exists
   ansible.builtin.file:
     path: "{{ keycloak.home }}/data/{{ item | lower }}"
     state: directory

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -61,9 +61,9 @@
   ansible.builtin.assert:
     that:
       - item.id is defined and item.id | length > 0
-      - (item.spi is defined and item.spi | length > 0) or (item.url is defined and item.url | length > 0)
+      - (item.spi is defined and item.spi | length > 0) or (item.url is defined and item.url | length > 0) or (item.maven is defined and item.maven.repository_url is defined and item.maven.repository_url | length > 0 and item.maven.group_id is defined and item.maven.group_id | length > 0 and item.maven.artifact_id is defined and item.maven.artifact_id | length > 0)
     quiet: true
-    fail_msg: "Providers definition is incorrect; `id` and one of `spi` or `url` are mandatory. `key` and `value` are mandatory for each property"
+    fail_msg: "Providers definition is incorrect; `id` and one of `spi`, `url`, or `maven` are mandatory. `key` and `value` are mandatory for each property"
   loop: "{{ keycloak_quarkus_providers }}"
 
 - name: "Validate policies"

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -61,9 +61,9 @@
   ansible.builtin.assert:
     that:
       - item.id is defined and item.id | length > 0
-      - (item.spi is defined and item.spi | length > 0) or (item.url is defined and item.url | length > 0) or (item.maven is defined and item.maven.repository_url is defined and item.maven.repository_url | length > 0 and item.maven.group_id is defined and item.maven.group_id | length > 0 and item.maven.artifact_id is defined and item.maven.artifact_id | length > 0)
+      - (item.spi is defined and item.spi | length > 0) or (item.url is defined and item.url | length > 0) or (item.maven is defined and item.maven.repository_url is defined and item.maven.repository_url | length > 0 and item.maven.group_id is defined and item.maven.group_id | length > 0 and item.maven.artifact_id is defined and item.maven.artifact_id | length > 0) or (item.local_path is defined and item.local_path | length > 0)
     quiet: true
-    fail_msg: "Providers definition is incorrect; `id` and one of `spi`, `url`, or `maven` are mandatory. `key` and `value` are mandatory for each property"
+    fail_msg: "Providers definition is incorrect; `id` and one of `spi`, `url`, `local_path`, or `maven` are mandatory. `key` and `value` are mandatory for each property"
   loop: "{{ keycloak_quarkus_providers }}"
 
 - name: "Validate policies"


### PR DESCRIPTION
Extends support for custom providers ("SPIs"): while previously only http downloads were supported, the new provider definition allows for maven downloads (e.g., Apache Maven Central,  Github Apache Maven (requires authn via a PAT)).

The new providers definition looks like:

```yaml
keycloak_quarkus_providers:
  - id: http-client                         # required
    spi: connections                        # required if url is not specified
  - id: http-client                         # required; "{{ id }}.jar" identifies the file name on RHBK
    spi: connections                        # required if neither url, local_path nor maven are specified; required for setting properties
    default: true                           # optional, whether to set default for spi, default false
    restart: true                           # optional, whether to restart, default true
    url: https://.../.../custom_spi.jar     # optional, url for download
    url: https://.../.../custom_spi.jar     # optional, url for download via http
    local_path: my_theme_spi.jar            # optional, path on local controller for SPI to be uploaded
    maven:                                  # optional, for download using maven
      repository_url: https://maven.pkg.github.com/OWNER/REPOSITORY # optional, maven repo url
      group_id:  my.group                   # optional, maven group id
      artifact_id: artifact                 # optional, maven artifact id
      version: 24.0.4                       # optional, defaults to latest
      username:  user                       # optional, cf. https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages
      password: pat                         # optional, provide a PAT for accessing Github's Apache Maven registry
    properties:                             # optional, list of key-values
```

* `lxml` is a new python dependency for this collection (however, it was already present because it is also a dependency of `middleware_automation.common`

Close #222 