### PR TITLE
`proxy-header` enhancement

### DIFF
--- a/molecule/debian/converge.yml
+++ b/molecule/debian/converge.yml
@@ -2,6 +2,7 @@
 - name: Converge
   hosts: all
   vars:
+    keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_realm: TestRealm
     keycloak_quarkus_log: file

--- a/molecule/https_revproxy/converge.yml
+++ b/molecule/https_revproxy/converge.yml
@@ -1,7 +1,8 @@
 ---
 - name: Converge
   hosts: all
-  vars: 
+  vars:
+    keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_admin_password: "remembertochangeme"
     keycloak_realm: TestRealm

--- a/molecule/quarkus-devmode/converge.yml
+++ b/molecule/quarkus-devmode/converge.yml
@@ -1,7 +1,8 @@
 ---
 - name: Converge
   hosts: all
-  vars: 
+  vars:
+    keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_admin_password: "remembertochangeme"
     keycloak_realm: TestRealm

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -2,6 +2,7 @@
 - name: Converge
   hosts: all
   vars:
+    keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_admin_password: "remembertochangeme"
     keycloak_realm: TestRealm

--- a/molecule/quarkus_ha/converge.yml
+++ b/molecule/quarkus_ha/converge.yml
@@ -2,6 +2,7 @@
 - name: Converge
   hosts: keycloak
   vars:
+    keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_admin_password: "remembertochangeme"
     keycloak_realm: TestRealm

--- a/molecule/quarkus_upgrade/converge.yml
+++ b/molecule/quarkus_upgrade/converge.yml
@@ -4,6 +4,7 @@
   vars_files:
     - vars.yml
   vars:
+    keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_version: 24.0.3
   roles:
     - role: keycloak_quarkus

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -167,6 +167,7 @@ Role Defaults
 |`keycloak_quarkus_start_dev`| Whether to start the service in development mode (start-dev) | `False` |
 |`keycloak_quarkus_transaction_xa_enabled`| Whether to use XA transactions | `True` |
 |`keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route`| If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies and we rely on the session affinity capabilities from reverse proxy | `True` |
+|`keycloak_quarkus_show_deprecation_warnings`| Whether deprecation warnings should be shown | `True` |
 
 
 #### Vault SPI

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -91,7 +91,10 @@ keycloak_quarkus_hostname_strict: true
 # If all applications use the public URL this option should be enabled.
 keycloak_quarkus_hostname_strict_backchannel: false
 
-# proxy address forwarding mode if the server is behind a reverse proxy. [none, edge, reencrypt, passthrough]
+# The proxy headers that should be accepted by the server. ['', 'forwarded', 'xforwarded']
+keycloak_quarkus_proxy_headers: ""
+
+# deprecated: proxy address forwarding mode if the server is behind a reverse proxy. [none, edge, reencrypt, passthrough]
 keycloak_quarkus_proxy_mode: edge
 
 # disable xa transactions

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -8,6 +8,8 @@ keycloak_quarkus_installdir: "{{ keycloak_quarkus_dest }}/keycloak-{{ keycloak_q
 # whether to install from local archive
 keycloak_quarkus_offline_install: false
 
+keycloak_quarkus_show_deprecation_warnings: true
+
 ### Install location and service settings
 keycloak_quarkus_java_home:
 keycloak_quarkus_dest: /opt/keycloak

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -456,7 +456,7 @@ argument_specs:
     downstream:
         options:
             rhbk_version:
-                default: "24.0.4"
+                default: "24.0.3"
                 description: "Red Hat Build of Keycloak version"
                 type: "str"
             rhbk_archive:

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -483,6 +483,10 @@ argument_specs:
                 default: false
                 description: "Perform an offline install"
                 type: "bool"
+            keycloak_quarkus_show_deprecation_warnings:
+                default: true
+                description: "Whether deprecation warnings should be shown"
+                type: "bool"
             rhbk_service_name:
                 default: "rhbk"
                 description: "systemd service name for Red Hat Build of Keycloak"

--- a/roles/keycloak_quarkus/tasks/deprecations.yml
+++ b/roles/keycloak_quarkus/tasks/deprecations.yml
@@ -34,3 +34,20 @@
 
     - name: Flush handlers
       ansible.builtin.meta: flush_handlers
+
+# https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/24.0/html-single/upgrading_guide/index#deprecated_literal_proxy_literal_option
+- name: Check deprecation of keycloak_quarkus_proxy_mode
+  delegate_to: localhost
+  run_once: true
+  when:
+    - keycloak_quarkus_proxy_mode is defined
+    - keycloak_quarkus_proxy_headers is defined and keycloak_quarkus_proxy_headers | length == 0
+    - keycloak_quarkus_version.split('.') | first | int >= 24
+  changed_when: true
+  ansible.builtin.set_fact:
+    deprecated_variable: "keycloak_quarkus_proxy_mode" # read in deprecation handler
+  notify:
+    - print deprecation warning
+
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers

--- a/roles/keycloak_quarkus/tasks/deprecations.yml
+++ b/roles/keycloak_quarkus/tasks/deprecations.yml
@@ -10,7 +10,7 @@
         - keycloak_quarkus_key_store_file is defined
         - keycloak_quarkus_key_store_file != ''
         - keycloak_quarkus_https_key_store_file == keycloak.home + "/conf/key_store.p12" # default value
-      changed_when: true
+      changed_when: keycloak_quarkus_show_deprecation_warnings
       ansible.builtin.set_fact:
         keycloak_quarkus_https_key_store_file: "{{ keycloak_quarkus_key_store_file }}"
         deprecated_variable: "keycloak_quarkus_key_store_file" # read in deprecation handler
@@ -25,7 +25,7 @@
         - keycloak_quarkus_key_store_password is defined
         - keycloak_quarkus_key_store_password != ''
         - keycloak_quarkus_https_key_store_password == "" # default value
-      changed_when: true
+      changed_when: keycloak_quarkus_show_deprecation_warnings
       ansible.builtin.set_fact:
         keycloak_quarkus_https_key_store_password: "{{ keycloak_quarkus_key_store_password }}"
         deprecated_variable: "keycloak_quarkus_key_store_password" # read in deprecation handler
@@ -37,13 +37,13 @@
 
 # https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/24.0/html-single/upgrading_guide/index#deprecated_literal_proxy_literal_option
 - name: Check deprecation of keycloak_quarkus_proxy_mode
-  delegate_to: localhost
-  run_once: true
   when:
     - keycloak_quarkus_proxy_mode is defined
     - keycloak_quarkus_proxy_headers is defined and keycloak_quarkus_proxy_headers | length == 0
     - keycloak_quarkus_version.split('.') | first | int >= 24
-  changed_when: true
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
   ansible.builtin.set_fact:
     deprecated_variable: "keycloak_quarkus_proxy_mode" # read in deprecation handler
   notify:

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -93,3 +93,10 @@
     fail_msg: "Additional env variable definition is incorrect: `key` and `value` are mandatory."
   no_log: true
   loop: "{{ keycloak_quarkus_additional_env_vars }}"
+
+- name: "Validate proxy-headers"
+  ansible.builtin.assert:
+    that:
+      - keycloak_quarkus_proxy_headers | lower in ['', 'forwarded', 'xforwarded']
+    quiet: true
+    fail_msg: "keycloak_quarkus_proxy_headers must be either '', 'forwarded' or 'xforwarded'"

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -69,13 +69,12 @@ cache-config-file=cache-ispn.xml
 {% endif %}
 {% endif %}
 
-{% if keycloak_quarkus_proxy_mode is defined and keycloak_quarkus_proxy_mode != "none" %}
-# Deprecated Proxy configuration
-proxy={{ keycloak_quarkus_proxy_mode }}
-{% endif %}
 {% if keycloak_quarkus_proxy_headers is defined and keycloak_quarkus_proxy_headers != "none" %}
 # Proxy
 proxy-headers={{ keycloak_quarkus_proxy_headers }}
+{% elif keycloak_quarkus_proxy_mode is defined and keycloak_quarkus_proxy_mode != "none" %}
+# Deprecated Proxy configuration
+proxy={{ keycloak_quarkus_proxy_mode }}
 {% endif %}
 
 spi-sticky-session-encoder-infinispan-should-attach-route={{ keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route | d(true) | lower }}

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -69,9 +69,8 @@ cache-config-file=cache-ispn.xml
 {% endif %}
 {% endif %}
 
-{% if keycloak_quarkus_proxy_headers is defined and keycloak_quarkus_proxy_headers != "none" %}
-# Proxy
-proxy-headers={{ keycloak_quarkus_proxy_headers }}
+{% if keycloak_quarkus_proxy_headers | length > 0 %}
+proxy-headers={{ keycloak_quarkus_proxy_headers | lower }}
 {% elif keycloak_quarkus_proxy_mode is defined and keycloak_quarkus_proxy_mode != "none" %}
 # Deprecated Proxy configuration
 proxy={{ keycloak_quarkus_proxy_mode }}


### PR DESCRIPTION
Deprecated `proxy` setting will only be emitted in keycloak.conf if `keycloak_quarkus_proxy_headers` is not set.

Fix #226