### PR TITLE
Allow to add extra custom env vars in sysconfig file

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -38,7 +38,8 @@ Role Defaults
 |`keycloak_quarkus_java_home`| JAVA_HOME of installed JRE, leave empty for using specified keycloak_quarkus_jvm_package RPM path | `None` |
 |`keycloak_quarkus_java_heap_opts`| Heap memory JVM setting | `-Xms1024m -Xmx2048m` |
 |`keycloak_quarkus_java_jvm_opts`| Other JVM settings | same as keycloak |
-|`keycloak_quarkus_java_opts`| JVM arguments; if overriden, it takes precedence over `keycloak_quarkus_java_*` | `{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}` |
+|`keycloak_quarkus_java_opts`| JVM arguments; if overridden, it takes precedence over `keycloak_quarkus_java_*` | `{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}` |
+|`keycloak_quarkus_additional_env_vars` | List of additional env variables of { key: str, value: str} to be put in sysconfig file | `[]` |
 |`keycloak_quarkus_frontend_url`| Set the base URL for frontend URLs, including scheme, host, port and path | |
 |`keycloak_quarkus_admin_url`| Set the base URL for accessing the administration console, including scheme, host, port and path | |
 |`keycloak_quarkus_http_relative_path` | Set the path relative to / for serving resources. The path must start with a / | `/` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -44,6 +44,7 @@ keycloak_quarkus_java_jvm_opts: "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m
   -Djava.security.egd=file:/dev/urandom -XX:+UseParallelGC -XX:GCTimeRatio=4
   -XX:AdaptiveSizePolicyWeight=90 -XX:FlightRecorderOptions=stackdepth=512"
 keycloak_quarkus_java_opts: "{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}"
+keycloak_quarkus_additional_env_vars: []
 
 ### TLS/HTTPS configuration
 keycloak_quarkus_https_key_file_enabled: false

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -201,6 +201,10 @@ argument_specs:
                 default: "{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}"
                 description: "JVM arguments, by default heap_opts + jvm_opts, if overriden it takes precedence over them"
                 type: "str"
+            keycloak_quarkus_additional_env_vars:
+                default: "[]"
+                description: "List of additional env variables of { key: str, value: str} to be put in sysconfig file"
+                type: "list"
             keycloak_quarkus_ha_enabled:
                 default: false
                 description: "Enable auto configuration for database backend, clustering and remote caches on infinispan"

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -75,3 +75,13 @@
     quiet: true
     fail_msg: "Policy definition is incorrect: `name` and one of `url` are mandatory, `type` needs to be left empty or one of {{ keycloak_quarkus_supported_policy_types }}."
   loop: "{{ keycloak_quarkus_policies }}"
+
+- name: "Validate additional env variables"
+  ansible.builtin.assert:
+    that:
+      - item.key is defined and item.key | length > 0
+      - item.value is defined and item.value | length > 0
+    quiet: true
+    fail_msg: "Additional env variable definition is incorrect: `key` and `value` are mandatory."
+  no_log: true
+  loop: "{{ keycloak_quarkus_additional_env_vars }}"

--- a/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
@@ -8,3 +8,8 @@ KEYCLOAK_ADMIN_PASSWORD='{{ keycloak_quarkus_admin_pass }}'
 PATH={{ keycloak_quarkus_java_home | default(keycloak_sys_pkg_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 JAVA_HOME={{ keycloak_quarkus_java_home | default(keycloak_sys_pkg_java_home, true) }}
 JAVA_OPTS={{ keycloak_quarkus_java_opts }}
+
+# Custom ENV variables
+{% for env in keycloak_quarkus_additional_env_vars %}
+{{ env.key }}={{ env.value }}
+{% endfor %}


### PR DESCRIPTION
New parameter:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_additional_env_vars` | List of additional env variables of { key: str, value: str } to be put in sysconfig file | `[]` |


Close #228 