### PR TITLE
Close #182, #221: improve restart handler logic

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -66,6 +66,7 @@ Role Defaults
 |`keycloak_quarkus_admin_url`| Set the base URL for accessing the administration console, including scheme, host, port and path | |
 |`keycloak_quarkus_http_relative_path` | Set the path relative to / for serving resources. The path must start with a / | `/` |
 |`keycloak_quarkus_http_enabled`| Enable listener on HTTP port | `True` |
+|`keycloak_quarkus_health_check_url_path`| Path to the health check endpoint; scheme, host and keycloak_quarkus_http_relative_path will be prepended automatically | `realms/master/.well-known/openid-configuration` |
 |`keycloak_quarkus_https_key_file_enabled`| Enable listener on HTTPS port | `False` |
 |`keycloak_quarkus_key_file_copy_enabled`| Enable copy of key file to target host | `False` |
 |`keycloak_quarkus_key_content`| Content of the TLS private key. Use `"{{ lookup('file', 'server.key.pem') }}"` to lookup a file. | `""` |

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -104,6 +104,10 @@ argument_specs:
                 default: 8080
                 description: "HTTP port"
                 type: "int"
+            keycloak_quarkus_health_check_url_path:
+                default: "realms/master/.well-known/openid-configuration"
+                description: "Path to the health check endpoint; scheme, host and keycloak_quarkus_http_relative_path will be prepended automatically"
+                type: "str"
             keycloak_quarkus_https_key_file_enabled:
                 default: false
                 description: "Enable configuration of HTTPS via files in PEM format"

--- a/roles/keycloak_quarkus/tasks/restart.yml
+++ b/roles/keycloak_quarkus/tasks/restart.yml
@@ -1,9 +1,38 @@
 ---
-- name: "Restart and enable {{ keycloak.service_name }} service"
+- name: Ensure only one service at a time gets rebooted, to ensure replication of distributed ispn caches
   throttle: 1
-  ansible.builtin.systemd:
-    name: keycloak
-    enabled: true
-    state: restarted
-    daemon_reload: true
-  become: true
+  block:
+    - name: "Restart and enable {{ keycloak.service_name }} service on first host"
+      ansible.builtin.systemd:
+        name: "{{ keycloak.service_name }}"
+        enabled: true
+        state: restarted
+        daemon_reload: true
+      become: true
+      delegate_to: "{{ ansible_play_hosts | first }}"
+      run_once: true
+
+    - name: "Wait until {{ keycloak.service_name }} service becomes active {{ keycloak.health_url }}"
+      ansible.builtin.uri:
+        url: "{{ keycloak.health_url }}"
+      register: keycloak_status
+      until: keycloak_status.status == 200
+      retries: 25
+      delay: 10
+      delegate_to: "{{ ansible_play_hosts | first }}"
+      run_once: true
+
+    - name: Pause to give distributed ispn caches time to (re-)replicate back onto first host
+      ansible.builtin.pause:
+        seconds: 15
+      when:
+        - rhbk_ha_enabled
+
+    - name: "Restart and enable {{ keycloak.service_name }} service on all other hosts"
+      ansible.builtin.systemd:
+        name: "{{ keycloak.service_name }}"
+        enabled: true
+        state: restarted
+        daemon_reload: true
+      become: true
+      when: inventory_hostname != ansible_play_hosts | first

--- a/roles/keycloak_quarkus/tasks/restart.yml
+++ b/roles/keycloak_quarkus/tasks/restart.yml
@@ -26,7 +26,7 @@
       ansible.builtin.pause:
         seconds: 15
       when:
-        - rhbk_ha_enabled
+        - keycloak_quarkus_ha_enabled
 
     - name: "Restart and enable {{ keycloak.service_name }} service on all other hosts"
       ansible.builtin.systemd:

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -4,7 +4,7 @@ keycloak: # noqa var-naming this is an internal dict of interpolated values
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "http://{{ keycloak_quarkus_host }}:{{ keycloak_quarkus_http_port }}{{ keycloak_quarkus_http_relative_path }}{{ '/' \
+  health_url: "{{ 'https' if keycloak_quarkus_http_enabled == False else 'http' }}://{{ keycloak_quarkus_host }}:{{ keycloak_quarkus_https_port if keycloak_quarkus_http_enabled == False else keycloak_quarkus_http_port }}{{ keycloak_quarkus_http_relative_path }}{{ '/' \
                if keycloak_quarkus_http_relative_path | length > 1 else '' }}realms/master/.well-known/openid-configuration"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -5,7 +5,7 @@ keycloak: # noqa var-naming this is an internal dict of interpolated values
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
   health_url: "{{ 'https' if keycloak_quarkus_http_enabled == False else 'http' }}://{{ keycloak_quarkus_host }}:{{ keycloak_quarkus_https_port if keycloak_quarkus_http_enabled == False else keycloak_quarkus_http_port }}{{ keycloak_quarkus_http_relative_path }}{{ '/' \
-               if keycloak_quarkus_http_relative_path | length > 1 else '' }}realms/master/.well-known/openid-configuration"
+               if keycloak_quarkus_http_relative_path | length > 1 else '' }}{{ keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration') }}"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"
   service_group: "{{ keycloak_quarkus_service_group }}"


### PR DESCRIPTION
This does restart sequentially (at least a single node gets restarted, then the others);

@guidograzioli:
* [ ] not sure whether you want to check the health differently (`wait_for_healthy` as you stated in #182), but I guess this is the right PR to tackle all these.
* [x] Re: #221:
  > [..] but it would be great to have this part parametrized as well as this part: /realms/master/.well-known/openid-configuration

  This does not seem fruitful since the `master` realm needs to exist always afaik, so this is the perfect place to check against, wdyt?
  
* [x] Re: CI: Not sure why the molecule tests fail, any pointers? Surely it's related to the `health_url`, but I don't see how...
