### PR TITLE
Enable by default health check on restart

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -102,7 +102,7 @@ Role Defaults
 |`keycloak_quarkus_systemd_wait_for_timeout`| How long to wait for service to be alive (seconds) | `60` |
 |`keycloak_quarkus_systemd_wait_for_delay`| Activation delay for service systemd unit (seconds) | `10` |
 |`keycloak_quarkus_restart_strategy`| Strategy task file for restarting in HA (one of provided restart/['serial.yml','none.yml','serial_then_parallel.yml']) or path to file when providing custom strategy | `restart/serial.yml` |
-|`keycloak_quarkus_restart_health_check`| Whether to wait for successful health check after restart | `{{ keycloak_quarkus_ha_enabled }}` |
+|`keycloak_quarkus_restart_health_check`| Whether to wait for successful health check after restart | `true` |
 |`keycloak_quarkus_restart_health_check_delay`| Seconds to let pass before starting healch checks | `10` |
 |`keycloak_quarkus_restart_health_check_reries`| Number of attempts for successful health check before failing | `25` |
 |`keycloak_quarkus_restart_pause`| Seconds to wait between restarts in HA strategy | `15` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -161,7 +161,7 @@ keycloak_quarkus_supported_policy_types: ['password-blacklists']
 
 # files in restart directory (one of [ 'serial', 'none', 'serial_then_parallel' ]), or path to file when providing custom strategy
 keycloak_quarkus_restart_strategy: restart/serial.yml
-keycloak_quarkus_restart_health_check: "{{ keycloak_quarkus_ha_enabled }}"
+keycloak_quarkus_restart_health_check: true
 keycloak_quarkus_restart_health_check_delay: 10
 keycloak_quarkus_restart_health_check_reries: 25
 keycloak_quarkus_restart_pause: 15

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -432,7 +432,7 @@ argument_specs:
                 description: "Allow the option to ignore invalid certificates when downloading JDBC drivers from a custom URL"
                 type: "bool"
             keycloak_quarkus_restart_health_check:
-                default: "{{ keycloak_quarkus_ha_enabled }}"
+                default: true
                 description: "Whether to wait for successful health check after restart"
                 type: "bool"
             keycloak_quarkus_restart_strategy:


### PR DESCRIPTION
New default for `keycloak_quarkus_restart_health_check` is `true` (was: true if `keycloak_quarkus_ha_enabled`).

Fix #233 