### PR TITLE
Add wait_for_port number parameter

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -98,6 +98,7 @@ Role Defaults
 |`keycloak_quarkus_db_enabled`| Enable auto configuration for database backend | `True` if `keycloak_quarkus_ha_enabled` is True, else `False` |
 |`keycloak_quarkus_jgroups_port`| jgroups cluster tcp port | `7800` |
 |`keycloak_quarkus_systemd_wait_for_port` | Whether systemd unit should wait for keycloak port before returning | `{{ keycloak_quarkus_ha_enabled }}` |
+|`keycloak_quarkus_systemd_wait_for_port_number`| Which port the systemd unit should wait for | `{{ keycloak_quarkus_https_port }}` |
 |`keycloak_quarkus_systemd_wait_for_log` | Whether systemd unit should wait for service to be up in logs | `false` |
 |`keycloak_quarkus_systemd_wait_for_timeout`| How long to wait for service to be alive (seconds) | `60` |
 |`keycloak_quarkus_systemd_wait_for_delay`| Activation delay for service systemd unit (seconds) | `10` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -74,6 +74,7 @@ keycloak_quarkus_ha_discovery: "TCPPING"
 ### Enable database configuration, must be enabled when HA is configured
 keycloak_quarkus_db_enabled: "{{ keycloak_quarkus_ha_enabled }}"
 keycloak_quarkus_systemd_wait_for_port: "{{ keycloak_quarkus_ha_enabled }}"
+keycloak_quarkus_systemd_wait_for_port_number: "{{ keycloak_quarkus_https_port }}"
 keycloak_quarkus_systemd_wait_for_log: false
 keycloak_quarkus_systemd_wait_for_timeout: 60
 keycloak_quarkus_systemd_wait_for_delay: 10

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -386,6 +386,10 @@ argument_specs:
                 description: 'Whether systemd unit should wait for keycloak port before returning'
                 default: "{{ keycloak_quarkus_ha_enabled }}"
                 type: "bool"
+            keycloak_quarkus_systemd_wait_for_port_number:
+                default: "{{ keycloak_quarkus_https_port }}"
+                description: "The port the systemd unit should wait for, by default the https port"
+                type: "int"
             keycloak_quarkus_systemd_wait_for_log:
                 description: 'Whether systemd unit should wait for service to be up in logs'
                 default: false

--- a/roles/keycloak_quarkus/templates/keycloak.service.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.service.j2
@@ -23,7 +23,7 @@ RestartSec={{ keycloak_quarkus_service_restartsec }}
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 {% endif %}
 {% if keycloak_quarkus_systemd_wait_for_port %}
-ExecStartPost=/usr/bin/timeout {{ keycloak_quarkus_systemd_wait_for_timeout }} sh -c 'while ! ss -H -t -l -n sport = :{{ keycloak_quarkus_https_port }} | grep -q "^LISTEN.*:{{ keycloak_quarkus_https_port }}"; do sleep 1; done && /bin/sleep {{ keycloak_quarkus_systemd_wait_for_delay }}'
+ExecStartPost=/usr/bin/timeout {{ keycloak_quarkus_systemd_wait_for_timeout }} sh -c 'while ! ss -H -t -l -n sport = :{{ keycloak_quarkus_systemd_wait_for_port_number }} | grep -q "^LISTEN.*:{{ keycloak_quarkus_systemd_wait_for_port_number }}"; do sleep 1; done && /bin/sleep {{ keycloak_quarkus_systemd_wait_for_delay }}'
 {% endif %}
 {% if keycloak_quarkus_systemd_wait_for_log %}
 ExecStartPost=/usr/bin/timeout {{ keycloak_quarkus_systemd_wait_for_timeout }} sh -c 'cat {{ keycloak.log.file }} | sed "/Profile.*activated/ q" && /bin/sleep {{ keycloak_quarkus_systemd_wait_for_delay }}'


### PR DESCRIPTION
Allow to set which port to wait for in the systemd unit, when keycloak_quarkus_systemd_wait_for_port is enabled, with the new parameter `keycloak_quarkus_systemd_wait_for_port`(int). It is by default `keycloak_quarkus_https_port`, so no changes are required if the setting is not needed.

Fix #236 