### PR TITLE
New parameter `keycloak_quarkus_download_path` 

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -34,6 +34,7 @@ warn_list:
 skip_list:
   - vars_should_not_be_used
   - file_is_small_enough
+  - file_has_valid_name
   - name[template]
   - var-naming[no-role-prefix]
 

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -30,6 +30,7 @@ warn_list:
   - schema[meta]
   - key-order[task]
   - blocked_modules
+  - run-once[task]
 
 skip_list:
   - vars_should_not_be_used

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/_build/
 changelogs/.plugin-cache.yaml
 *.pem
 *.key
+*.p12

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,61 +2,46 @@
 - name: Converge
   hosts: all
   vars:
+    keycloak_quarkus_show_deprecation_warnings: false
+    keycloak_quarkus_admin_pass: "remembertochangeme"
     keycloak_admin_password: "remembertochangeme"
-    keycloak_jvm_package: java-11-openjdk-headless
-    keycloak_modcluster_enabled: True
-    keycloak_modcluster_urls:
-      - host: myhost1
-        port: 16667
-      - host: myhost2
-        port: 16668
-    keycloak_jboss_port_offset: 10
-    keycloak_log_target: /tmp/keycloak
+    keycloak_quarkus_host: instance
+    keycloak_quarkus_log: file
+    keycloak_quarkus_log_level: debug
+    keycloak_quarkus_log_target: /tmp/keycloak
+    keycloak_quarkus_start_dev: True
+    keycloak_quarkus_proxy_mode: none
+    keycloak_quarkus_offline_install: true
+    keycloak_quarkus_download_path: /tmp/keycloak/
   roles:
-    - role: keycloak
-  tasks:
-    - name: Keycloak Realm Role
-      ansible.builtin.include_role:
-        name: keycloak_realm
-      vars:
-        keycloak_client_default_roles:
-          - TestRoleAdmin
-          - TestRoleUser
-        keycloak_client_users:
-          - username: TestUser
-            password: password
-            client_roles:
-              - client: TestClient
-                role: TestRoleUser
-                realm: "{{ keycloak_realm }}"
-          - username: TestAdmin
-            password: password
-            client_roles:
-              - client: TestClient
-                role: TestRoleUser
-                realm: "{{ keycloak_realm }}"
-              - client: TestClient
-                role: TestRoleAdmin
-                realm: "{{ keycloak_realm }}"
-        keycloak_realm: TestRealm
-        keycloak_clients:
-          - name: TestClient
-            roles: "{{ keycloak_client_default_roles }}"
-            realm: "{{ keycloak_realm }}"
-            public_client: "{{ keycloak_client_public }}"
-            web_origins: "{{ keycloak_client_web_origins }}"
-            users: "{{ keycloak_client_users }}"
-            client_id: TestClient
-            attributes:
-              post.logout.redirect.uris: '/public/logout'
-  pre_tasks:
-    - name: "Retrieve assets server from env"
-      ansible.builtin.set_fact:
-        assets_server: "{{ lookup('env', 'MIDDLEWARE_DOWNLOAD_RELEASE_SERVER_URL') }}"
-
-    - name: "Set offline when assets server from env is defined"
-      ansible.builtin.set_fact:
-        sso_offline_install: True
-      when:
-        - assets_server is defined
-        - assets_server | length > 0
+    - role: keycloak_quarkus
+    - role: keycloak_realm
+      keycloak_context: ''
+      keycloak_client_default_roles:
+        - TestRoleAdmin
+        - TestRoleUser
+      keycloak_client_users:
+        - username: TestUser
+          password: password
+          client_roles:
+            - client: TestClient
+              role: TestRoleUser
+              realm: "{{ keycloak_realm }}"
+        - username: TestAdmin
+          password: password
+          client_roles:
+            - client: TestClient
+              role: TestRoleUser
+              realm: "{{ keycloak_realm }}"
+            - client: TestClient
+              role: TestRoleAdmin
+              realm: "{{ keycloak_realm }}"
+      keycloak_realm: TestRealm
+      keycloak_clients:
+        - name: TestClient
+          roles: "{{ keycloak_client_default_roles }}"
+          realm: "{{ keycloak_realm }}"
+          public_client: "{{ keycloak_client_public }}"
+          web_origins: "{{ keycloak_client_web_origins }}"
+          users: "{{ keycloak_client_users }}"
+          client_id: TestClient

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -12,18 +12,18 @@
           - "{{ assets_server }}/sso/7.6.0/rh-sso-7.6.0-server-dist.zip"
           - "{{ assets_server }}/sso/7.6.1/rh-sso-7.6.1-patch.zip"
 
-    - name: Install JDK8
-      become: yes
-      ansible.builtin.yum:
-        name:
-          - java-1.8.0-openjdk
-        state: present
-      when: ansible_facts['os_family'] == "RedHat"
+    - name: Create controller directory for downloads
+      ansible.builtin.file: # noqa risky-file-permissions delegated, uses controller host user
+        path: /tmp/keycloak
+        state: directory
+        mode: '0750'
+      delegate_to: localhost
+      run_once: true
 
-    - name: Install JDK8
-      become: yes
-      ansible.builtin.apt:
-        name:
-          - openjdk-8-jdk
-        state: present
-      when: ansible_facts['os_family'] == "Debian"
+    - name: Download keycloak archive to controller directory
+      ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
+        url: https://github.com/keycloak/keycloak/releases/download/24.0.4/keycloak-24.0.4.zip
+        dest: /tmp/keycloak
+        mode: '0640'
+      delegate_to: localhost
+      run_once: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,10 +3,7 @@
   hosts: all
   vars:
     keycloak_admin_password: "remembertochangeme"
-    keycloak_jvm_package: java-11-openjdk-headless
-    keycloak_uri: "http://localhost:{{ 8080 + ( keycloak_jboss_port_offset | default(0) ) }}"
-    keycloak_management_port: "http://localhost:{{ 9990 + ( keycloak_jboss_port_offset | default(0) ) }}"
-    keycloak_jboss_port_offset: 10
+    keycloak_uri: "http://localhost:8080"
   tasks:
     - name: Populate service facts
       ansible.builtin.service_facts:
@@ -15,16 +12,9 @@
         that:
           - ansible_facts.services["keycloak.service"]["state"] == "running"
           - ansible_facts.services["keycloak.service"]["status"] == "enabled"
-    - name: Verify we are running on requested jvm # noqa blocked_modules command-instead-of-module
-      ansible.builtin.shell: |
-        set -o pipefail
-        ps -ef | grep '/etc/alternatives/jre_11/' | grep -v grep
-      args:
-        executable: /bin/bash
-      changed_when: no
     - name: Verify token api call
       ansible.builtin.uri:
-        url: "{{ keycloak_uri }}/auth/realms/master/protocol/openid-connect/token"
+        url: "{{ keycloak_uri }}/realms/master/protocol/openid-connect/token"
         method: POST
         body: "client_id=admin-cli&username=admin&password={{ keycloak_admin_password }}&grant_type=password"
         validate_certs: no
@@ -32,58 +22,3 @@
       until: keycloak_auth_response.status == 200
       retries: 2
       delay: 2
-    - name: Fetch openid-connect config
-      ansible.builtin.uri:
-        url: "{{ keycloak_uri }}/auth/realms/TestRealm/.well-known/openid-configuration"
-        method: GET
-        validate_certs: no
-        status_code: 200
-      register: keycloak_openid_config
-    - name: Verify expected config
-      ansible.builtin.assert:
-        that:
-          - keycloak_openid_config.json.registration_endpoint == 'http://localhost:8080/auth/realms/TestRealm/clients-registrations/openid-connect'
-    - name: Get test realm clients
-      ansible.builtin.uri:
-        url: "{{ keycloak_uri }}/auth/admin/realms/TestRealm/clients"
-        method: GET
-        validate_certs: no
-        status_code: 200
-        headers:
-          Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
-      register: keycloak_query_clients
-    - name: Verify expected config
-      ansible.builtin.assert:
-        that:
-          - (keycloak_query_clients.json | selectattr('clientId','equalto','TestClient') | first)["attributes"]["post.logout.redirect.uris"] == '/public/logout'
-    - name: "Privilege escalation as some files/folders may requires it"
-      become: yes
-      block:
-        - name: Check log folder
-          ansible.builtin.stat:
-            path: "/tmp/keycloak"
-          register: keycloak_log_folder
-        - name: Check that keycloak log folder exists and is a link
-          ansible.builtin.assert:
-            that:
-              - keycloak_log_folder.stat.exists
-              - not keycloak_log_folder.stat.isdir
-              - keycloak_log_folder.stat.islnk
-        - name: Check log file
-          ansible.builtin.stat:
-            path: "/tmp/keycloak/server.log"
-          register: keycloak_log_file
-        - name: Check if keycloak file exists
-          ansible.builtin.assert:
-            that:
-              - keycloak_log_file.stat.exists
-              - not keycloak_log_file.stat.isdir
-        - name: Check default log folder
-          ansible.builtin.stat:
-            path: "/var/log/keycloak"
-          register: keycloak_default_log_folder
-          failed_when: false
-        - name: Check that default keycloak log folder doesn't exist
-          ansible.builtin.assert:
-            that:
-              - not keycloak_default_log_folder.stat.exists

--- a/molecule/quarkus/prepare.yml
+++ b/molecule/quarkus/prepare.yml
@@ -12,14 +12,14 @@
     - name: Create certificate request
       ansible.builtin.command: openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj '/CN=instance'
       delegate_to: localhost
-      changed_when: False
+      changed_when: false
 
     - name: Create vault directory
       become: true
       ansible.builtin.file:
         state: directory
         path: "/opt/keycloak/vault"
-        mode: 0755
+        mode: '0755'
 
     - name: Make sure a jre is available (for keytool to prepare keystore)
       delegate_to: localhost
@@ -41,4 +41,4 @@
       ansible.builtin.copy:
         src: keystore.p12
         dest: /opt/keycloak/vault/keystore.p12
-        mode: 0444
+        mode: '0444'

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -37,6 +37,7 @@ Role Defaults
 |`keycloak_quarkus_offline_install` | Perform an offline install | `False`|
 |`keycloak_quarkus_dest`| Installation root path | `/opt/keycloak` |
 |`keycloak_quarkus_download_url` | Download URL for keycloak | `https://github.com/keycloak/keycloak/releases/download/{{ keycloak_quarkus_version }}/{{ keycloak_quarkus_archive }}` |
+|`keycloak_quarkus_download_path`| Path local to controller for offline/download of install archives | `{{ lookup('env', 'PWD') }}` |
 
 
 #### Service configuration

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -15,6 +15,7 @@ keycloak_quarkus_java_home:
 keycloak_quarkus_dest: /opt/keycloak
 keycloak_quarkus_home: "{{ keycloak_quarkus_installdir }}"
 keycloak_quarkus_config_dir: "{{ keycloak_quarkus_home }}/conf"
+keycloak_quarkus_download_path: "{{ lookup('env', 'PWD') }}"
 keycloak_quarkus_start_dev: false
 keycloak_quarkus_service_user: keycloak
 keycloak_quarkus_service_group: keycloak

--- a/roles/keycloak_quarkus/handlers/main.yml
+++ b/roles/keycloak_quarkus/handlers/main.yml
@@ -10,7 +10,7 @@
   ansible.builtin.include_tasks:
     file: "{{ keycloak_quarkus_restart_strategy if keycloak_quarkus_ha_enabled else 'restart.yml' }}"
   listen: "restart keycloak"
-- name: "Print deprecation warning"
+- name: "Display deprecation warning"
   ansible.builtin.fail:
     msg: "Deprecation warning: you are using the deprecated variable '{{ deprecated_variable | d('NotSet') }}', check docs on how to upgrade."
   failed_when: false

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -56,15 +56,15 @@ argument_specs:
                 default: false
                 description: "Ensure firewalld is running and configure keycloak ports"
                 type: "bool"
-            keycloak_service_restart_always:
+            keycloak_quarkus_service_restart_always:
                 default: false
                 description: "systemd restart always behavior of service; takes precedence over keycloak_service_restart_on_failure if true"
                 type: "bool"
-            keycloak_service_restart_on_failure:
+            keycloak_quarkus_service_restart_on_failure:
                 default: false
                 description: "systemd restart on-failure behavior of service"
                 type: "bool"
-            keycloak_service_restartsec:
+            keycloak_quarkus_service_restartsec:
                 default: "10s"
                 description: "systemd RestartSec for service"
                 type: "str"
@@ -457,6 +457,14 @@ argument_specs:
                 description: "Number of attempts for successful health check before failing"
                 default: 25
                 type: 'int'
+            keycloak_quarkus_show_deprecation_warnings:
+                default: true
+                description: "Whether or not deprecation warnings should be shown"
+                type: "bool"
+            keycloak_quarkus_download_path:
+                description: "Path local to controller for offline/download of install archives"
+                default: "{{ lookup('env', 'PWD') }}"
+                type: "str"
     downstream:
         options:
             rhbk_version:
@@ -486,10 +494,6 @@ argument_specs:
             rhbk_offline_install:
                 default: false
                 description: "Perform an offline install"
-                type: "bool"
-            keycloak_quarkus_show_deprecation_warnings:
-                default: true
-                description: "Whether deprecation warnings should be shown"
                 type: "bool"
             rhbk_service_name:
                 default: "rhbk"

--- a/roles/keycloak_quarkus/tasks/bootstrapped.yml
+++ b/roles/keycloak_quarkus/tasks/bootstrapped.yml
@@ -1,5 +1,5 @@
 ---
-- name: Write ansible custom facts
+- name: Save ansible custom facts
   become: true
   ansible.builtin.template:
     src: keycloak.fact.j2
@@ -8,7 +8,7 @@
   vars:
     bootstrapped: true
 
-- name: Re-read custom facts
+- name: Refresh custom facts
   ansible.builtin.setup:
     filter: ansible_local
 

--- a/roles/keycloak_quarkus/tasks/config_store.yml
+++ b/roles/keycloak_quarkus/tasks/config_store.yml
@@ -8,7 +8,7 @@
 - name: "Initialize empty configuration key store"
   become: true
   # keytool doesn't allow creating an empty key store, so this is a hacky way around it
-  ansible.builtin.shell: |
+  ansible.builtin.shell: | # noqa blocked_modules shell is necessary here
     set -o nounset   # abort on unbound variable
     set -o pipefail  # do not hide errors within pipes
     set -o errexit   # abort on nonzero exit status
@@ -19,7 +19,7 @@
     creates: "{{ keycloak_quarkus_config_key_store_file }}"
 
 - name: "Set configuration key store using keytool"
-  ansible.builtin.shell: |
+  ansible.builtin.shell: | # noqa blocked_modules shell is necessary here
     set -o nounset   # abort on unbound variable
     set -o pipefail  # do not hide errors within pipes
 
@@ -36,7 +36,7 @@
     fi
 
     echo {{ item.value | quote }} | keytool -noprompt -importpass -alias {{ item.key | quote }} -keystore {{ keycloak_quarkus_config_key_store_file | quote }} -storepass {{ keycloak_quarkus_config_key_store_password | quote }} -storetype PKCS12
-  with_items: "{{ store_items }}"
+  loop: "{{ store_items }}"
   no_log: true
   become: true
   changed_when: true

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -8,6 +8,7 @@
       - keycloak_quarkus_archive is defined
       - keycloak_quarkus_download_url is defined
       - keycloak_quarkus_version is defined
+      - local_path is defined
     quiet: true
 
 - name: Check for an existing deployment
@@ -52,14 +53,6 @@
   register: archive_path
 
 ## download to controller
-- name: Check local download archive path
-  ansible.builtin.stat:
-    path: "{{ lookup('env', 'PWD') }}"
-  register: local_path
-  delegate_to: localhost
-  run_once: true
-  become: false
-
 - name: Download keycloak archive
   ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
     url: "{{ keycloak_quarkus_download_url }}"
@@ -244,7 +237,7 @@
   no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
   notify: "{{ ['rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or not item.restart else [] }}"
 
-- name: "Upload local maven providers"
+- name: "Copy maven providers"
   ansible.builtin.copy:
     src: "{{ local_path.stat.path }}/{{ item.id }}.jar"
     dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"
@@ -256,7 +249,7 @@
   when: item.maven is defined
   no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
 
-- name: "Upload local providers"
+- name: "Copy providers"
   ansible.builtin.copy:
     src: "{{ item.local_path }}"
     dest: "{{ keycloak.home }}/providers/{{ item.id }}.jar"

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -91,7 +91,7 @@
   register: keycloak_service_status
   changed_when: false
 
-- name: "Trigger bootstrapped notification: remove `keycloak_quarkus_admin_user[_pass]` env vars"
+- name: "Notify to remove `keycloak_quarkus_admin_user[_pass]` env vars"
   when:
     - not ansible_local.keycloak.general.bootstrapped | default(false) | bool # it was not bootstrapped prior to the current role's execution
     - keycloak_service_status.status.ActiveState == "active"                  # but it is now

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -43,10 +43,50 @@
   vars:
     packages_list: "{{ keycloak_quarkus_prereq_package_list }}"
 
+- name: Check local download archive path
+  ansible.builtin.stat:
+    path: "{{ keycloak_quarkus_download_path }}"
+  register: local_path
+  delegate_to: localhost
+  run_once: true
+  become: false
+
+- name: Validate local download path
+  ansible.builtin.assert:
+    that:
+      - local_path.stat.exists
+      - local_path.stat.readable
+      - keycloak_quarkus_offline_install or local_path.stat.writeable
+    quiet: true
+    fail_msg: "Defined controller path for downloading resource is incorrect: {{ keycloak_quarkus_download_path }}"
+    success_msg: "Will download resource to controller path: {{ local_path.stat.path }}"
+  delegate_to: localhost
+  run_once: true
+
+- name: Check downloaded archive if offline
+  ansible.builtin.stat:
+    path: "{{ local_path.stat.path }}/{{ keycloak.bundle }}"
+  when: keycloak_quarkus_offline_install
+  register: local_archive_path_check
+  delegate_to: localhost
+  run_once: true
+
+- name: Validate local downloaded archive if offline
+  ansible.builtin.assert:
+    that:
+      - local_archive_path_check.stat.exists
+      - local_archive_path_check.stat.readable
+    quiet: true
+    fail_msg: "Configured for offline install but install archive not found at: {{ local_archive_path_check.stat.path }}"
+    success_msg: "Will install offline with expected archive: {{ local_archive_path_check.stat.path }}"
+  when: keycloak_quarkus_offline_install
+  delegate_to: localhost
+  run_once: true
+
 - name: "Validate keytool"
   when: keycloak_quarkus_config_key_store_password | length > 0
   block:
-    - name: "Attempt to run keytool"
+    - name: "Check run keytool"
       changed_when: false
       ansible.builtin.command: keytool -help
       register: keytool_check

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -58,8 +58,8 @@
       - local_path.stat.readable
       - keycloak_quarkus_offline_install or local_path.stat.writeable
     quiet: true
-    fail_msg: "Defined controller path for downloading resource is incorrect: {{ keycloak_quarkus_download_path }}"
-    success_msg: "Will download resource to controller path: {{ local_path.stat.path }}"
+    fail_msg: "Defined controller path for downloading resources is incorrect or unreadable: {{ keycloak_quarkus_download_path }}"
+    success_msg: "Will download resource to controller path: {{ keycloak_quarkus_download_path }}"
   delegate_to: localhost
   run_once: true
 
@@ -77,8 +77,8 @@
       - local_archive_path_check.stat.exists
       - local_archive_path_check.stat.readable
     quiet: true
-    fail_msg: "Configured for offline install but install archive not found at: {{ local_archive_path_check.stat.path }}"
-    success_msg: "Will install offline with expected archive: {{ local_archive_path_check.stat.path }}"
+    fail_msg: "Configured for offline install but install archive not found at: {{ local_path.stat.path }}/{{ keycloak.bundle }}"
+    success_msg: "Will install offline with expected archive: {{ local_path.stat.path }}/{{ keycloak.bundle }}"
   when: keycloak_quarkus_offline_install
   delegate_to: localhost
   run_once: true

--- a/roles/keycloak_quarkus/tasks/rebuild_config.yml
+++ b/roles/keycloak_quarkus/tasks/rebuild_config.yml
@@ -1,7 +1,7 @@
 ---
 # cf. https://www.keycloak.org/server/configuration#_optimize_the_keycloak_startup
 - name: "Rebuild {{ keycloak.service_name }} config"
-  ansible.builtin.shell: |
+  ansible.builtin.shell: | # noqa blocked_modules shell is necessary here
     {{ keycloak.home }}/bin/kc.sh build
   environment:
     PATH: "{{ keycloak_quarkus_java_home | default(keycloak_quarkus_pkg_java_home, true) }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/roles/keycloak_quarkus/tasks/restart.yml
+++ b/roles/keycloak_quarkus/tasks/restart.yml
@@ -16,7 +16,7 @@
   delay: "{{ keycloak_quarkus_restart_health_check_delay }}"
   when: internal_force_health_check | default(keycloak_quarkus_restart_health_check)
 
-- name: Pause to give distributed ispn caches time to (re-)replicate back onto first host
+- name: Wait to give distributed ispn caches time to (re-)replicate back onto first host
   ansible.builtin.pause:
     seconds: "{{ keycloak_quarkus_restart_pause }}"
   when:


### PR DESCRIPTION
The new parameter allows to specify the path to be used on controller for downloading install tarballs.

| Variable | Description | Default |
|:---------|:------------|:--------|
|`keycloak_quarkus_download_path`| Path local to controller for offline/download of install archives | `{{ lookup('env', 'PWD') }}` |

The default is backwards compatible so no change is necessary; when an offline install is performed, existence of install tarballs is checked in the specified path before starting installation.

Internal: CI molecule test `default` now tests keycloak in offline mode (instead of keycloak-legacy)

Fix #238 