### PR TITLE
Role support for keycloak/RHBK v26

### DIFF
--- a/molecule/debian/converge.yml
+++ b/molecule/debian/converge.yml
@@ -5,7 +5,7 @@
     keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
-    keycloak_quarkus_host: instance
+    keycloak_quarkus_hostname: http://instance
     keycloak_quarkus_log: file
     keycloak_quarkus_start_dev: true
     keycloak_quarkus_proxy_mode: none

--- a/molecule/debian/converge.yml
+++ b/molecule/debian/converge.yml
@@ -5,14 +5,17 @@
     keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
-    keycloak_quarkus_hostname: http://instance
+    keycloak_quarkus_hostname: http://instance:8080
     keycloak_quarkus_log: file
     keycloak_quarkus_start_dev: true
     keycloak_quarkus_proxy_mode: none
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm
+      keycloak_url: "{{ keycloak_quarkus_hostname }}"
       keycloak_context: ''
+      keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
+      keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_users:
         - username: TestUser
           password: password

--- a/molecule/debian/converge.yml
+++ b/molecule/debian/converge.yml
@@ -3,8 +3,8 @@
   hosts: all
   vars:
     keycloak_quarkus_show_deprecation_warnings: false
-    keycloak_quarkus_admin_pass: "remembertochangeme"
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_quarkus_host: instance
     keycloak_quarkus_log: file
     keycloak_quarkus_start_dev: true

--- a/molecule/debian/prepare.yml
+++ b/molecule/debian/prepare.yml
@@ -7,5 +7,6 @@
       ansible.builtin.apt:
         name:
           - sudo
+          # - openjdk-21-jdk-headless # this is not available in ghcr.io/hspaans/molecule-containers:debian-11 (neither in debian-12) since the images are using outdated package sources
           - openjdk-17-jdk-headless
         state: present

--- a/molecule/debian/verify.yml
+++ b/molecule/debian/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify
   hosts: all
   vars:
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_uri: "http://localhost:{{ 8080 + ( keycloak_jboss_port_offset | default(0) ) }}"
     keycloak_management_port: "http://localhost:{{ 9990 + ( keycloak_jboss_port_offset | default(0) ) }}"
     keycloak_jboss_port_offset: 10

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,8 +3,8 @@
   hosts: all
   vars:
     keycloak_quarkus_show_deprecation_warnings: false
-    keycloak_quarkus_admin_pass: "remembertochangeme"
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_quarkus_host: instance
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: debug

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
     keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
-    keycloak_quarkus_host: instance
+    keycloak_quarkus_hostname: http://instance
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: debug
     keycloak_quarkus_log_target: /tmp/keycloak

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
     keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
-    keycloak_quarkus_hostname: http://instance
+    keycloak_quarkus_hostname: http://instance:8080
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: debug
     keycloak_quarkus_log_target: /tmp/keycloak
@@ -16,7 +16,10 @@
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm
+      keycloak_url: "{{ keycloak_quarkus_hostname }}"
       keycloak_context: ''
+      keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
+      keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_users:
         - username: TestUser
           password: password

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,7 @@ platforms:
       - "8080/tcp"
       - "8443/tcp"
       - "8009/tcp"
+      - "9000/tcp"
 provisioner:
   name: ansible
   config_options:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -22,7 +22,7 @@
 
     - name: Download keycloak archive to controller directory
       ansible.builtin.get_url: # noqa risky-file-permissions delegated, uses controller host user
-        url: https://github.com/keycloak/keycloak/releases/download/24.0.5/keycloak-24.0.5.zip
+        url: https://github.com/keycloak/keycloak/releases/download/26.0.7/keycloak-26.0.7.zip
         dest: /tmp/keycloak
         mode: '0640'
       delegate_to: localhost

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,6 +2,7 @@
 - name: Verify
   hosts: all
   vars:
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_uri: "http://localhost:8080"
   tasks:
@@ -16,7 +17,7 @@
       ansible.builtin.uri:
         url: "{{ keycloak_uri }}/realms/master/protocol/openid-connect/token"
         method: POST
-        body: "client_id=admin-cli&username=admin&password={{ keycloak_quarkus_bootstrap_admin_user }}&grant_type=password"
+        body: "client_id=admin-cli&username={{ keycloak_quarkus_bootstrap_admin_user }}&password={{ keycloak_quarkus_bootstrap_admin_user }}&grant_type=password"
         validate_certs: no
       register: keycloak_auth_response
       until: keycloak_auth_response.status == 200

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify
   hosts: all
   vars:
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_uri: "http://localhost:8080"
   tasks:
     - name: Populate service facts
@@ -16,7 +16,7 @@
       ansible.builtin.uri:
         url: "{{ keycloak_uri }}/realms/master/protocol/openid-connect/token"
         method: POST
-        body: "client_id=admin-cli&username=admin&password={{ keycloak_admin_password }}&grant_type=password"
+        body: "client_id=admin-cli&username=admin&password={{ keycloak_quarkus_bootstrap_admin_user }}&grant_type=password"
         validate_certs: no
       register: keycloak_auth_response
       until: keycloak_auth_response.status == 200

--- a/molecule/https_revproxy/converge.yml
+++ b/molecule/https_revproxy/converge.yml
@@ -3,8 +3,8 @@
   hosts: all
   vars:
     keycloak_quarkus_show_deprecation_warnings: false
-    keycloak_quarkus_admin_pass: "remembertochangeme"
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
     keycloak_quarkus_host: instance
     keycloak_quarkus_log: file

--- a/molecule/https_revproxy/converge.yml
+++ b/molecule/https_revproxy/converge.yml
@@ -6,7 +6,7 @@
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
-    keycloak_quarkus_host: instance
+    keycloak_quarkus_hostname: http://instance
     keycloak_quarkus_log: file
     keycloak_quarkus_http_enabled: True
     keycloak_quarkus_http_port: 8080

--- a/molecule/https_revproxy/converge.yml
+++ b/molecule/https_revproxy/converge.yml
@@ -5,13 +5,12 @@
     keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
-    keycloak_realm: TestRealm
-    keycloak_quarkus_hostname: http://instance
+    keycloak_quarkus_hostname: https://proxy
     keycloak_quarkus_log: file
     keycloak_quarkus_http_enabled: True
     keycloak_quarkus_http_port: 8080
     keycloak_quarkus_proxy_mode: edge
     keycloak_quarkus_http_relative_path: /
-    keycloak_quarkus_frontend_url: https://proxy/
+    keycloak_quarkus_health_check_url: http://proxy:8080/realms/master/.well-known/openid-configuration
   roles:
     - role: keycloak_quarkus

--- a/molecule/overridexml/molecule.yml
+++ b/molecule/overridexml/molecule.yml
@@ -11,6 +11,7 @@ platforms:
       - "8080/tcp"
       - "8443/tcp"
       - "8009/tcp"
+      - "9000/tcp"
 provisioner:
   name: ansible
   config_options:

--- a/molecule/quarkus-devmode/converge.yml
+++ b/molecule/quarkus-devmode/converge.yml
@@ -3,8 +3,8 @@
   hosts: all
   vars:
     keycloak_quarkus_show_deprecation_warnings: false
-    keycloak_quarkus_admin_pass: "remembertochangeme"
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
     keycloak_quarkus_log: file
     keycloak_quarkus_frontend_url: 'http://localhost:8080/'

--- a/molecule/quarkus-devmode/converge.yml
+++ b/molecule/quarkus-devmode/converge.yml
@@ -7,14 +7,17 @@
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
     keycloak_quarkus_log: file
-    keycloak_quarkus_frontend_url: 'http://localhost:8080/'
+    keycloak_quarkus_hostname: 'http://localhost:8080'
     keycloak_quarkus_start_dev: True
     keycloak_quarkus_proxy_mode: none
     keycloak_quarkus_java_home: /opt/openjdk/
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm
+      keycloak_url: "{{ keycloak_quarkus_hostname }}"
       keycloak_context: ''
+      keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
+      keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_default_roles:
         - TestRoleAdmin
         - TestRoleUser

--- a/molecule/quarkus-devmode/molecule.yml
+++ b/molecule/quarkus-devmode/molecule.yml
@@ -10,8 +10,10 @@ platforms:
     port_bindings:
       - "8080/tcp"
       - "8009/tcp"
+      - "9000/tcp"
     published_ports:
       - 0.0.0.0:8080:8080/tcp
+      - 0.0.0.0:9000:9000/TCP
 provisioner:
   name: ansible
   config_options:

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -3,8 +3,8 @@
   hosts: all
   vars:
     keycloak_quarkus_show_deprecation_warnings: false
-    keycloak_quarkus_admin_pass: "remembertochangeme"
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
     keycloak_quarkus_host: instance
     keycloak_quarkus_log: file

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -6,7 +6,7 @@
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
-    keycloak_quarkus_host: instance
+    keycloak_quarkus_hostname: http://instance
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: debug # needed for the verify step
     keycloak_quarkus_https_key_file_enabled: true

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -6,7 +6,7 @@
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
-    keycloak_quarkus_hostname: http://instance
+    keycloak_quarkus_hostname: https://instance:8443
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: debug # needed for the verify step
     keycloak_quarkus_https_key_file_enabled: true
@@ -37,7 +37,7 @@
           repository_url: https://repo1.maven.org/maven2/ # https://mvnrepository.com/artifact/org.keycloak/keycloak-kerberos-federation/24.0.4
           group_id: org.keycloak
           artifact_id: keycloak-kerberos-federation
-          version: 24.0.5 # optional
+          version: 26.0.7 # optional
           # username: myUser # optional
           # password: myPAT # optional
       # - id: my-static-theme
@@ -51,7 +51,10 @@
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm
+      keycloak_url: "{{ keycloak_quarkus_hostname }}"
       keycloak_context: ''
+      keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
+      keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_default_roles:
         - TestRoleAdmin
         - TestRoleUser

--- a/molecule/quarkus/molecule.yml
+++ b/molecule/quarkus/molecule.yml
@@ -11,6 +11,7 @@ platforms:
       - "8080/tcp"
       - "8443/tcp"
       - "8009/tcp"
+      - "9000/tcp"
     published_ports:
       - 0.0.0.0:8443:8443/tcp
 provisioner:

--- a/molecule/quarkus/prepare.yml
+++ b/molecule/quarkus/prepare.yml
@@ -24,7 +24,7 @@
     - name: Make sure a jre is available (for keytool to prepare keystore)
       delegate_to: localhost
       ansible.builtin.package:
-        name: "{{ 'java-17-openjdk-headless' if hera_home | length > 0 else 'openjdk-17-jdk-headless' }}"
+        name: "{{ 'java-21-openjdk-headless' if hera_home | length > 0 else 'openjdk-21-jdk-headless' }}"
         state: present
       become: true
       failed_when: false

--- a/molecule/quarkus/verify.yml
+++ b/molecule/quarkus/verify.yml
@@ -2,7 +2,8 @@
 - name: Verify
   hosts: all
   vars:
-     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
   tasks:
     - name: Populate service facts
       ansible.builtin.service_facts:
@@ -35,10 +36,10 @@
         - name: Verify endpoint URLs
           ansible.builtin.assert:
             that:
-              - (openid_config.stdout | from_json)["backchannel_authentication_endpoint"] == 'https://instance/realms/master/protocol/openid-connect/ext/ciba/auth'
-              - (openid_config.stdout | from_json)['issuer'] == 'https://instance/realms/master'
-              - (openid_config.stdout | from_json)['authorization_endpoint'] == 'https://instance/realms/master/protocol/openid-connect/auth'
-              - (openid_config.stdout | from_json)['token_endpoint'] == 'https://instance/realms/master/protocol/openid-connect/token'
+              - (openid_config.stdout | from_json)["backchannel_authentication_endpoint"] == 'https://instance:8443/realms/master/protocol/openid-connect/ext/ciba/auth'
+              - (openid_config.stdout | from_json)['issuer'] == 'https://instance:8443/realms/master'
+              - (openid_config.stdout | from_json)['authorization_endpoint'] == 'https://instance:8443/realms/master/protocol/openid-connect/auth'
+              - (openid_config.stdout | from_json)['token_endpoint'] == 'https://instance:8443/realms/master/protocol/openid-connect/token'
           delegate_to: localhost
 
     - name: Check log folder
@@ -91,7 +92,7 @@
       ansible.builtin.uri:
         url: "https://instance:8443/realms/master/protocol/openid-connect/token"
         method: POST
-        body: "client_id=admin-cli&username=admin&password={{ keycloak_quarkus_bootstrap_admin_user }}&grant_type=password"
+        body: "client_id=admin-cli&username={{ keycloak_quarkus_bootstrap_admin_user }}&password={{ keycloak_quarkus_bootstrap_admin_password}}&grant_type=password"
         validate_certs: no
       register: keycloak_auth_response
       until: keycloak_auth_response.status == 200

--- a/molecule/quarkus/verify.yml
+++ b/molecule/quarkus/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify
   hosts: all
   vars:
-     keycloak_admin_password: "remembertochangeme"
+     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
   tasks:
     - name: Populate service facts
       ansible.builtin.service_facts:
@@ -91,7 +91,7 @@
       ansible.builtin.uri:
         url: "https://instance:8443/realms/master/protocol/openid-connect/token"
         method: POST
-        body: "client_id=admin-cli&username=admin&password={{ keycloak_admin_password }}&grant_type=password"
+        body: "client_id=admin-cli&username=admin&password={{ keycloak_quarkus_bootstrap_admin_user }}&grant_type=password"
         validate_certs: no
       register: keycloak_auth_response
       until: keycloak_auth_response.status == 200

--- a/molecule/quarkus_ha/converge.yml
+++ b/molecule/quarkus_ha/converge.yml
@@ -5,8 +5,7 @@
     keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
-    keycloak_realm: TestRealm
-    keycloak_quarkus_hostname: "http://{{ inventory_hostname }}"
+    keycloak_quarkus_hostname: "http://{{ inventory_hostname }}:8080"
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: info
     keycloak_quarkus_https_key_file_enabled: true

--- a/molecule/quarkus_ha/converge.yml
+++ b/molecule/quarkus_ha/converge.yml
@@ -3,8 +3,8 @@
   hosts: keycloak
   vars:
     keycloak_quarkus_show_deprecation_warnings: false
-    keycloak_quarkus_admin_pass: "remembertochangeme"
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
     keycloak_quarkus_host: "{{ inventory_hostname }}"
     keycloak_quarkus_log: file

--- a/molecule/quarkus_ha/converge.yml
+++ b/molecule/quarkus_ha/converge.yml
@@ -6,7 +6,7 @@
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
     keycloak_realm: TestRealm
-    keycloak_quarkus_host: "{{ inventory_hostname }}"
+    keycloak_quarkus_hostname: "http://{{ inventory_hostname }}"
     keycloak_quarkus_log: file
     keycloak_quarkus_log_level: info
     keycloak_quarkus_https_key_file_enabled: true

--- a/molecule/quarkus_ha/molecule.yml
+++ b/molecule/quarkus_ha/molecule.yml
@@ -14,6 +14,7 @@ platforms:
     port_bindings:
       - "8080/tcp"
       - "8443/tcp"
+      - "9000/tcp"
   - name: instance2
     image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
@@ -26,6 +27,7 @@ platforms:
     port_bindings:
       - "8080/tcp"
       - "8443/tcp"
+      - "9000/tcp"
   - name: postgres
     image: ubuntu/postgres:14-22.04_beta
     pre_build_image: true

--- a/molecule/quarkus_upgrade/converge.yml
+++ b/molecule/quarkus_upgrade/converge.yml
@@ -5,6 +5,6 @@
     - vars.yml
   vars:
     keycloak_quarkus_show_deprecation_warnings: false
-    keycloak_quarkus_version: 24.0.3
+    keycloak_quarkus_version: 26.0.7
   roles:
     - role: keycloak_quarkus

--- a/molecule/quarkus_upgrade/molecule.yml
+++ b/molecule/quarkus_upgrade/molecule.yml
@@ -13,8 +13,10 @@ platforms:
     privileged: true
     port_bindings:
       - 8080:8080
+      - "9000/tcp"
     published_ports:
       - 0.0.0.0:8080:8080/TCP
+      - 0.0.0.0:9000:9000/TCP
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/quarkus_upgrade/prepare.yml
+++ b/molecule/quarkus_upgrade/prepare.yml
@@ -5,7 +5,7 @@
     - vars.yml
   vars:
     sudo_pkg_name: sudo
-    keycloak_quarkus_version: 23.0.7
+    keycloak_quarkus_version: 24.0.5
   pre_tasks:
     - name: Install sudo
       ansible.builtin.apt:

--- a/molecule/quarkus_upgrade/vars.yml
+++ b/molecule/quarkus_upgrade/vars.yml
@@ -1,7 +1,6 @@
 ---
 keycloak_quarkus_offline_install: false
-keycloak_quarkus_admin_password: "remembertochangeme"
-keycloak_quarkus_admin_pass: "remembertochangeme"
+keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
 keycloak_quarkus_realm: TestRealm
 keycloak_quarkus_host: instance
 keycloak_quarkus_log: file

--- a/molecule/quarkus_upgrade/vars.yml
+++ b/molecule/quarkus_upgrade/vars.yml
@@ -2,7 +2,7 @@
 keycloak_quarkus_offline_install: false
 keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
 keycloak_quarkus_realm: TestRealm
-keycloak_quarkus_host: instance
+keycloak_quarkus_hostname: http://instance
 keycloak_quarkus_log: file
 keycloak_quarkus_https_key_file_enabled: true
 keycloak_quarkus_log_target: /tmp/keycloak

--- a/molecule/quarkus_upgrade/vars.yml
+++ b/molecule/quarkus_upgrade/vars.yml
@@ -2,7 +2,7 @@
 keycloak_quarkus_offline_install: false
 keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
 keycloak_quarkus_realm: TestRealm
-keycloak_quarkus_hostname: http://instance
+keycloak_quarkus_hostname: http://instance:8080
 keycloak_quarkus_log: file
 keycloak_quarkus_https_key_file_enabled: true
 keycloak_quarkus_log_target: /tmp/keycloak

--- a/molecule/quarkus_upgrade/verify.yml
+++ b/molecule/quarkus_upgrade/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify
   hosts: instance
   vars:
-    keycloak_quarkus_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_port: http://localhost:8080
   tasks:
     - name: Populate service facts
@@ -24,7 +24,7 @@
       ansible.builtin.uri:
         url: "{{ keycloak_quarkus_port }}/realms/master/protocol/openid-connect/token"
         method: POST
-        body: "client_id=admin-cli&username=admin&password={{ keycloak_quarkus_admin_password }}&grant_type=password"
+        body: "client_id=admin-cli&username=admin&password={{ keycloak_quarkus_bootstrap_admin_password }}&grant_type=password"
         validate_certs: no
       register: keycloak_auth_response
       until: keycloak_auth_response.status == 200

--- a/molecule/quarkus_upgrade/verify.yml
+++ b/molecule/quarkus_upgrade/verify.yml
@@ -17,7 +17,7 @@
     - name: Verify we are running on requested jvm
       ansible.builtin.shell: |
         set -eo pipefail
-        ps -ef | grep 'etc/alternatives/.*17' | grep -v grep
+        ps -ef | grep 'etc/alternatives/.*21' | grep -v grep
       changed_when: false
 
     - name: Verify token api call

--- a/playbooks/keycloak_quarkus.yml
+++ b/playbooks/keycloak_quarkus.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     keycloak_quarkus_admin_pass: "remembertochangeme"
-    keycloak_quarkus_host: localhost
+    keycloak_quarkus_hostname: http://localhost
     keycloak_quarkus_port: 8443
     keycloak_quarkus_log: file
     keycloak_quarkus_proxy_mode: none

--- a/playbooks/keycloak_quarkus_dev.yml
+++ b/playbooks/keycloak_quarkus_dev.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     keycloak_admin_password: "remembertochangeme"
-    keycloak_quarkus_host: localhost
+    keycloak_quarkus_hostname: http://localhost
     keycloak_quarkus_port: 8080
     keycloak_quarkus_log: file
     keycloak_quarkus_start_dev: true

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -44,7 +44,8 @@ Role Defaults
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-|`keycloak_quarkus_admin_user`| Administration console user account | `admin` |
+|`keycloak_quarkus_bootstrap_admin_user`| Administration console user account | `admin` |
+|`keycloak_quarkus_admin_user`| Deprecated, use `keycloak_quarkus_bootstrap_admin_user` instead. | |
 |`keycloak_quarkus_bind_address`| Address for binding service ports | `0.0.0.0` |
 |`keycloak_quarkus_host`| Hostname for the Keycloak server | `localhost` |
 |`keycloak_quarkus_port`| The port used by the proxy when exposing the hostname | `-1` |
@@ -243,7 +244,8 @@ Role Variables
 
 | Variable | Description | Required |
 |:---------|:------------|----------|
-|`keycloak_quarkus_admin_pass`| Password of console admin account | `yes` |
+|`keycloak_quarkus_bootstrap_admin_password`| Password of console admin account | `yes` |
+|`keycloak_quarkus_admin_pass`| Deprecated, use `keycloak_quarkus_bootstrap_admin_password` instead. | |
 |`keycloak_quarkus_frontend_url`| Base URL for frontend URLs, including scheme, host, port and path | `no` |
 |`keycloak_quarkus_admin_url`| Base URL for accessing the administration console, including scheme, host, port and path | `no` |
 |`keycloak_quarkus_ks_vault_pass`| The password for accessing the keystore vault SPI | `no` |
@@ -265,7 +267,7 @@ The role uses the following [custom facts](https://docs.ansible.com/ansible/late
 
 | Variable | Description |
 |:---------|:------------|
-|`general.bootstrapped` | A custom fact indicating whether this role has been used for bootstrapping keycloak on the respective host before; set to `false` (e.g., when starting off with a new, empty database) ensures that the initial admin user as defined by `keycloak_quarkus_admin_user[_pass]` gets created |
+|`general.bootstrapped` | A custom fact indicating whether this role has been used for bootstrapping keycloak on the respective host before; set to `false` (e.g., when starting off with a new, empty database) ensures that the initial admin user as defined by `keycloak_quarkus_bootstrap_admin_user[_password]` gets created |
 
 License
 -------

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -59,7 +59,7 @@ Role Defaults
 |`keycloak_quarkus_service_restart_always`| systemd restart always behavior activation | `False` |
 |`keycloak_quarkus_service_restart_on_failure`| systemd restart on-failure behavior activation | `False` |
 |`keycloak_quarkus_service_restartsec`| systemd RestartSec | `10s` |
-|`keycloak_quarkus_jvm_package`| RHEL java package runtime | `java-17-openjdk-headless` |
+|`keycloak_quarkus_jvm_package`| RHEL java package runtime | `java-21-openjdk-headless` |
 |`keycloak_quarkus_java_home`| JAVA_HOME of installed JRE, leave empty for using specified keycloak_quarkus_jvm_package RPM path | `None` |
 |`keycloak_quarkus_java_heap_opts`| Heap memory JVM setting | `-Xms1024m -Xmx2048m` |
 |`keycloak_quarkus_java_jvm_opts`| Other JVM settings | same as keycloak |

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -33,7 +33,7 @@ Role Defaults
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-|`keycloak_quarkus_version`| keycloak.org package version | `24.0.5` |
+|`keycloak_quarkus_version`| keycloak.org package version | `26.0.7` |
 |`keycloak_quarkus_offline_install` | Perform an offline install | `False`|
 |`keycloak_quarkus_dest`| Installation root path | `/opt/keycloak` |
 |`keycloak_quarkus_download_url` | Download URL for keycloak | `https://github.com/keycloak/keycloak/releases/download/{{ keycloak_quarkus_version }}/{{ keycloak_quarkus_archive }}` |

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -72,7 +72,8 @@ Role Defaults
 |`keycloak_quarkus_http_relative_path` | Set the path relative to / for serving resources. The path must start with a / | `/` |
 |`keycloak_quarkus_http_management_relative_path` | Set the path relative to / for serving resources from management interface. The path must start with a /. If not given, the value is inherited from HTTP options. Relevant only when something is exposed on the management interface - see the guide for details. | `/` |
 |`keycloak_quarkus_http_enabled`| Enable listener on HTTP port | `True` |
-|`keycloak_quarkus_health_check_url_path`| Path to the health check endpoint; scheme, host and keycloak_quarkus_http_relative_path will be prepended automatically | `realms/master/.well-known/openid-configuration` |
+|`keycloak_quarkus_health_check_url`| Full URL (including scheme, host, path, fragment etc.) used for health check endpoint; keycloak_quarkus_hostname will NOT be prepended; helpful when health checks should happen against http port, but keycloak_quarkus_hostname uses https scheme per default | `` |
+|`keycloak_quarkus_health_check_url_path`| Path to the health check endpoint; keycloak_quarkus_hostname will be prepended automatically; Note that keycloak_quarkus_health_check_url takes precedence over this property | `realms/master/.well-known/openid-configuration` |
 |`keycloak_quarkus_https_key_file_enabled`| Enable listener on HTTPS port | `False` |
 |`keycloak_quarkus_key_file_copy_enabled`| Enable copy of key file to target host | `False` |
 |`keycloak_quarkus_key_content`| Content of the TLS private key. Use `"{{ lookup('file', 'server.key.pem') }}"` to lookup a file. | `""` |

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -52,6 +52,7 @@ Role Defaults
 |`keycloak_quarkus_path`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
 |`keycloak_quarkus_http_port`| HTTP listening port | `8080` |
 |`keycloak_quarkus_https_port`| TLS HTTP listening port | `8443` |
+|`keycloak_quarkus_http_management_port`| Port of the management interface. Relevant only when something is exposed on the management interface - see the guide for details. | `9000` |
 |`keycloak_quarkus_ajp_port`| AJP port | `8009` |
 |`keycloak_quarkus_service_user`| Posix account username | `keycloak` |
 |`keycloak_quarkus_service_group`| Posix account group | `keycloak` |
@@ -69,6 +70,7 @@ Role Defaults
 |`keycloak_quarkus_admin`| Set the base URL for accessing the administration console, including scheme, host, port and path | |
 |`keycloak_quarkus_admin_url`| Deprecated, use `keycloak_quarkus_admin` instead. | |
 |`keycloak_quarkus_http_relative_path` | Set the path relative to / for serving resources. The path must start with a / | `/` |
+|`keycloak_quarkus_http_management_relative_path` | Set the path relative to / for serving resources from management interface. The path must start with a /. If not given, the value is inherited from HTTP options. Relevant only when something is exposed on the management interface - see the guide for details. | `/` |
 |`keycloak_quarkus_http_enabled`| Enable listener on HTTP port | `True` |
 |`keycloak_quarkus_health_check_url_path`| Path to the health check endpoint; scheme, host and keycloak_quarkus_http_relative_path will be prepended automatically | `realms/master/.well-known/openid-configuration` |
 |`keycloak_quarkus_https_key_file_enabled`| Enable listener on HTTPS port | `False` |
@@ -152,7 +154,7 @@ Role Defaults
 | Variable | Description | Default |
 |:---------|:------------|:--------|
 |`keycloak_quarkus_metrics_enabled`| Whether to enable metrics | `False` |
-|`keycloak_quarkus_health_enabled`| If the server should expose health check endpoints | `True` |
+|`keycloak_quarkus_health_enabled`| If the server should expose health check endpoints on the management interface | `True` |
 |`keycloak_quarkus_archive` | keycloak install archive filename | `keycloak-{{ keycloak_quarkus_version }}.zip` |
 |`keycloak_quarkus_installdir` | Installation path | `{{ keycloak_quarkus_dest }}/keycloak-{{ keycloak_quarkus_version }}` |
 |`keycloak_quarkus_home` | Installation work directory | `{{ keycloak_quarkus_installdir }}` |

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -47,9 +47,9 @@ Role Defaults
 |`keycloak_quarkus_bootstrap_admin_user`| Administration console user account | `admin` |
 |`keycloak_quarkus_admin_user`| Deprecated, use `keycloak_quarkus_bootstrap_admin_user` instead. | |
 |`keycloak_quarkus_bind_address`| Address for binding service ports | `0.0.0.0` |
-|`keycloak_quarkus_host`| Hostname for the Keycloak server | `localhost` |
-|`keycloak_quarkus_port`| The port used by the proxy when exposing the hostname | `-1` |
-|`keycloak_quarkus_path`| This should be set if proxy uses a different context-path for Keycloak | |
+|`keycloak_quarkus_host`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
+|`keycloak_quarkus_port`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
+|`keycloak_quarkus_path`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
 |`keycloak_quarkus_http_port`| HTTP listening port | `8080` |
 |`keycloak_quarkus_https_port`| TLS HTTP listening port | `8443` |
 |`keycloak_quarkus_ajp_port`| AJP port | `8009` |
@@ -64,8 +64,10 @@ Role Defaults
 |`keycloak_quarkus_java_jvm_opts`| Other JVM settings | same as keycloak |
 |`keycloak_quarkus_java_opts`| JVM arguments; if overridden, it takes precedence over `keycloak_quarkus_java_*` | `{{ keycloak_quarkus_java_heap_opts + ' ' + keycloak_quarkus_java_jvm_opts }}` |
 |`keycloak_quarkus_additional_env_vars` | List of additional env variables of { key: str, value: str} to be put in sysconfig file | `[]` |
-|`keycloak_quarkus_frontend_url`| Set the base URL for frontend URLs, including scheme, host, port and path | |
-|`keycloak_quarkus_admin_url`| Set the base URL for accessing the administration console, including scheme, host, port and path | |
+|`keycloak_quarkus_hostname`| Address at which is the server exposed. Can be a full URL, or just a hostname. When only hostname is provided, scheme, port and context path are resolved from the request. | |
+|`keycloak_quarkus_frontend_url`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
+|`keycloak_quarkus_admin`| Set the base URL for accessing the administration console, including scheme, host, port and path | |
+|`keycloak_quarkus_admin_url`| Deprecated, use `keycloak_quarkus_admin` instead. | |
 |`keycloak_quarkus_http_relative_path` | Set the path relative to / for serving resources. The path must start with a / | `/` |
 |`keycloak_quarkus_http_enabled`| Enable listener on HTTP port | `True` |
 |`keycloak_quarkus_health_check_url_path`| Path to the health check endpoint; scheme, host and keycloak_quarkus_http_relative_path will be prepended automatically | `realms/master/.well-known/openid-configuration` |
@@ -117,7 +119,8 @@ Role Defaults
 |:---------|:------------|:--------|
 |`keycloak_quarkus_http_relative_path`| Set the path relative to / for serving resources. The path must start with a / | `/` |
 |`keycloak_quarkus_hostname_strict`| Disables dynamically resolving the hostname from request headers | `true` |
-|`keycloak_quarkus_hostname_strict_backchannel`| By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. If all applications use the public URL this option should be enabled. | `false` |
+|`keycloak_quarkus_hostname_backchannel_dynamic`| Enables dynamic resolving of backchannel URLs, including hostname, scheme, port and context path. Set to true if your application accesses Keycloak via a private network. If set to true, hostname option needs to be specified as a full URL. | `false` |
+|`keycloak_quarkus_hostname_strict_backchannel`| Deprecated, use (the inverted!)`keycloak_quarkus_hostname_backchannel_dynamic` instead. |  |
 
 
 #### Database configuration
@@ -157,7 +160,6 @@ Role Defaults
 |`keycloak_quarkus_master_realm` | Name for rest authentication realm | `master` |
 |`keycloak_auth_client` | Authentication client for configuration REST calls | `admin-cli` |
 |`keycloak_force_install` | Remove pre-existing versions of service | `False` |
-|`keycloak_url` | URL for configuration rest calls | `http://{{ keycloak_quarkus_host }}:{{ keycloak_http_port }}` |
 |`keycloak_quarkus_log`| Enable one or more log handlers in a comma-separated list | `file` |
 |`keycloak_quarkus_log_level`| The log level of the root category or a comma-separated list of individual categories and their levels | `info` |
 |`keycloak_quarkus_log_file`| Set the log file path and filename relative to keycloak home | `data/log/keycloak.log` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ### Configuration specific to keycloak
-keycloak_quarkus_version: 24.0.5
+keycloak_quarkus_version: 26.0.7
 keycloak_quarkus_archive: "keycloak-{{ keycloak_quarkus_version }}.zip"
 keycloak_quarkus_download_url: "https://github.com/keycloak/keycloak/releases/download/{{ keycloak_quarkus_version }}/{{ keycloak_quarkus_archive }}"
 keycloak_quarkus_installdir: "{{ keycloak_quarkus_dest }}/keycloak-{{ keycloak_quarkus_version }}"

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -33,9 +33,6 @@ keycloak_quarkus_master_realm: master
 
 ### Configuration settings
 keycloak_quarkus_bind_address: 0.0.0.0
-keycloak_quarkus_host: localhost
-keycloak_quarkus_port: -1
-keycloak_quarkus_path:
 keycloak_quarkus_http_enabled: true
 keycloak_quarkus_http_port: 8080
 keycloak_quarkus_https_port: 8443
@@ -81,8 +78,8 @@ keycloak_quarkus_systemd_wait_for_timeout: 60
 keycloak_quarkus_systemd_wait_for_delay: 10
 
 ### keycloak frontend url
-keycloak_quarkus_frontend_url:
-keycloak_quarkus_admin_url:
+keycloak_quarkus_hostname:
+keycloak_quarkus_admin:
 
 ### Set the path relative to / for serving resources. The path must start with a /
 ### (set to `/auth` for retrocompatibility with pre-quarkus releases)
@@ -91,9 +88,9 @@ keycloak_quarkus_http_relative_path: /
 # Disables dynamically resolving the hostname from request headers.
 # Should always be set to true in production, unless proxy verifies the Host header.
 keycloak_quarkus_hostname_strict: true
-# By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications.
-# If all applications use the public URL this option should be enabled.
-keycloak_quarkus_hostname_strict_backchannel: false
+# Enables dynamic resolving of backchannel URLs, including hostname, scheme, port and context path.
+# Set to true if your application accesses Keycloak via a private network. If set to true, keycloak_quarkus_hostname option needs to be specified as a full URL.
+keycloak_quarkus_hostname_backchannel_dynamic: false
 
 # The proxy headers that should be accepted by the server. ['', 'forwarded', 'xforwarded']
 keycloak_quarkus_proxy_headers: ""

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -36,6 +36,7 @@ keycloak_quarkus_bind_address: 0.0.0.0
 keycloak_quarkus_http_enabled: true
 keycloak_quarkus_http_port: 8080
 keycloak_quarkus_https_port: 8443
+keycloak_quarkus_http_management_port: 9000
 keycloak_quarkus_ajp_port: 8009
 keycloak_quarkus_jgroups_port: 7800
 keycloak_quarkus_java_heap_opts: "-Xms1024m -Xmx2048m"

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -138,9 +138,9 @@ keycloak_quarkus_default_jdbc:
     version: 2.7.4
   mssql:
     url: 'jdbc:sqlserver://localhost:1433;databaseName=keycloak;'
-    version: 12.4.2
-    driver_jar_url: "https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.4.2.jre11/mssql-jdbc-12.4.2.jre11.jar"
-    # cf. https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/24.0/html/server_guide/db-#db-installing-the-microsoft-sql-server-driver
+    version: 12.8.1
+    driver_jar_url: "https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.8.1.jre11/mssql-jdbc-12.8.1.jre11.jar"
+    # cf. https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/server_configuration_guide/index#db-installing-the-microsoft-sql-server-driver
 ### logging configuration
 keycloak_quarkus_log: file
 keycloak_quarkus_log_level: info

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -27,8 +27,8 @@ keycloak_quarkus_configure_firewalld: false
 keycloak_quarkus_configure_iptables: false
 
 ### administrator console password
-keycloak_quarkus_admin_user: admin
-keycloak_quarkus_admin_pass:
+keycloak_quarkus_bootstrap_admin_user: admin
+keycloak_quarkus_bootstrap_admin_password:
 keycloak_quarkus_master_realm: master
 
 ### Configuration settings

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -22,7 +22,7 @@ argument_specs:
                 description: "Perform an offline install"
                 type: "bool"
             keycloak_quarkus_jvm_package:
-                default: "java-11-openjdk-headless"
+                default: "java-21-openjdk-headless"
                 description: "RHEL java package runtime"
                 type: "str"
             keycloak_quarkus_java_home:
@@ -479,7 +479,7 @@ argument_specs:
     downstream:
         options:
             rhbk_version:
-                default: "26.0.6"
+                default: "26.0.7"
                 description: "Red Hat Build of Keycloak version"
                 type: "str"
             rhbk_archive:

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -106,9 +106,12 @@ argument_specs:
                 default: 8080
                 description: "HTTP port"
                 type: "int"
+            keycloak_quarkus_health_check_url:
+                description: "Full URL (including scheme, host, path, fragment etc.) used for health check endpoint; keycloak_quarkus_hostname will NOT be prepended; helpful when health checks should happen against http port, but keycloak_quarkus_hostname uses https scheme per default"
+                type: "str"
             keycloak_quarkus_health_check_url_path:
                 default: "realms/master/.well-known/openid-configuration"
-                description: "Path to the health check endpoint; scheme, hostname will be prepended automatically"
+                description: "Path to the health check endpoint; keycloak_quarkus_hostname will be prepended automatically; Note that keycloak_quarkus_health_check_url takes precedence over this property"
                 type: "str"
             keycloak_quarkus_https_key_file_enabled:
                 default: false

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -2,7 +2,7 @@ argument_specs:
     main:
         options:
             keycloak_quarkus_version:
-                default: "24.0.5"
+                default: "26.0.7"
                 description: "keycloak.org package version"
                 type: "str"
             keycloak_quarkus_archive:
@@ -468,7 +468,7 @@ argument_specs:
     downstream:
         options:
             rhbk_version:
-                default: "24.0.3"
+                default: "26.0.6"
                 description: "Red Hat Build of Keycloak version"
                 type: "str"
             rhbk_archive:

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -108,7 +108,7 @@ argument_specs:
                 type: "int"
             keycloak_quarkus_health_check_url_path:
                 default: "realms/master/.well-known/openid-configuration"
-                description: "Path to the health check endpoint; scheme, host and keycloak_quarkus_http_relative_path will be prepended automatically"
+                description: "Path to the health check endpoint; scheme, hostname will be prepended automatically"
                 type: "str"
             keycloak_quarkus_https_key_file_enabled:
                 default: false
@@ -184,6 +184,10 @@ argument_specs:
                 default: 8443
                 description: "HTTPS port"
                 type: "int"
+            keycloak_quarkus_http_management_port:
+                default: 9000
+                description: "Port of the management interface. Relevant only when something is exposed on the management interface - see the guide for details."
+                type: "int"
             keycloak_quarkus_ajp_port:
                 default: 8009
                 description: "AJP port"
@@ -228,6 +232,10 @@ argument_specs:
                 default: /
                 description: "Set the path relative to / for serving resources. The path must start with a /"
                 type: "str"
+            keycloak_quarkus_http_management_relative_path:
+                required: false
+                description: "Set the path relative to / for serving resources from management interface. The path must start with a /. If not given, the value is inherited from HTTP options. Relevant only when something is exposed on the management interface - see the guide for details."
+                type: "str"
             keycloak_quarkus_frontend_url:
                 required: false
                 description: "Deprecated in v26, use keycloak_quarkus_hostname instead."
@@ -246,7 +254,7 @@ argument_specs:
                 type: "bool"
             keycloak_quarkus_health_enabled:
                 default: true
-                description: "If the server should expose health check endpoints"
+                description: "If the server should expose health check endpoints on the management interface"
                 type: "bool"
             keycloak_quarkus_ispn_user:
                 default: "supervisor"

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -68,13 +68,13 @@ argument_specs:
                 default: "10s"
                 description: "systemd RestartSec for service"
                 type: "str"
-            keycloak_quarkus_admin_user:
+            keycloak_quarkus_bootstrap_admin_user:
                 default: "admin"
-                description: "Administration console user account"
+                description: "Administration user account, only for bootstrapping"
                 type: "str"
-            keycloak_quarkus_admin_pass:
+            keycloak_quarkus_bootstrap_admin_password:
                 required: true
-                description: "Password of console admin account"
+                description: "Password of admin account, only for bootstrapping"
                 type: "str"
             keycloak_quarkus_master_realm:
                 default: "master"

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -84,17 +84,19 @@ argument_specs:
                 default: "0.0.0.0"
                 description: "Address for binding service ports"
                 type: "str"
+            keycloak_quarkus_hostname:
+                description: >-
+                    Address at which is the server exposed.
+                    Can be a full URL, or just a hostname. When only hostname is provided, scheme, port and context path are resolved from the request.
+                type: "str"
             keycloak_quarkus_host:
-                default: "localhost"
-                description: "Hostname for the Keycloak server"
+                description: "Deprecated in v26, use keycloak_quarkus_hostname instead."
                 type: "str"
             keycloak_quarkus_port:
-                default: -1
-                description: "The port used by the proxy when exposing the hostname"
+                description: "Deprecated in v26, use keycloak_quarkus_hostname instead."
                 type: "int"
             keycloak_quarkus_path:
-                required: false
-                description: "This should be set if proxy uses a different context-path for Keycloak"
+                description: "Deprecated in v26, use keycloak_quarkus_hostname instead."
                 type: "str"
             keycloak_quarkus_http_enabled:
                 default: true
@@ -228,11 +230,15 @@ argument_specs:
                 type: "str"
             keycloak_quarkus_frontend_url:
                 required: false
-                description: "Service public URL"
+                description: "Deprecated in v26, use keycloak_quarkus_hostname instead."
+                type: "str"
+            keycloak_quarkus_admin:
+                required: false
+                description: "Service URL for the admin console"
                 type: "str"
             keycloak_quarkus_admin_url:
                 required: false
-                description: "Service URL for the admin console"
+                description: "Deprecated in v26, use keycloak_quarkus_admin instead."
                 type: "str"
             keycloak_quarkus_metrics_enabled:
                 default: false
@@ -348,24 +354,18 @@ argument_specs:
                 description: >
                   Disables dynamically resolving the hostname from request headers. Should always be set to true in production, unless
                   proxy verifies the Host header.
-            keycloak_quarkus_hostname_strict_backchannel:
+            keycloak_quarkus_hostname_backchannel_dynamic:
                 default: false
                 type: "bool"
                 description: >
-                  By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. If all
-                  applications use the public URL this option should be enabled.
+                    Enables dynamic resolving of backchannel URLs, including hostname, scheme, port and context path.
+                    Set to true if your application accesses Keycloak via a private network. If set to true, hostname option needs to be specified as a full URL.
             keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route:
                 default: true
                 type: "bool"
                 description: >
                   If the route should be attached to cookies to reflect the node that owns a particular session. If false, route is not attached to cookies
                   and we rely on the session affinity capabilities from reverse proxy
-            keycloak_quarkus_hostname_strict_https:
-                type: "bool"
-                required: false
-                description: >
-                  By default, Keycloak requires running using TLS/HTTPS. If the service MUST run without TLS/HTTPS, then set
-                  this option to "true"
             keycloak_quarkus_ks_vault_enabled:
                 default: false
                 type: "bool"

--- a/roles/keycloak_quarkus/tasks/deprecations.yml
+++ b/roles/keycloak_quarkus/tasks/deprecations.yml
@@ -49,5 +49,101 @@
   notify:
     - print deprecation warning
 
+# https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/upgrading_guide/index#new_hostname_options
+- name: Check deprecation of keycloak_quarkus_frontend_url -> keycloak_quarkus_hostname
+  when:
+    - keycloak_quarkus_hostname is not defined
+    - keycloak_quarkus_frontend_url is defined
+    - keycloak_quarkus_frontend_url != ''
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
+  ansible.builtin.set_fact:
+    keycloak_quarkus_hostname: "{{ keycloak_quarkus_frontend_url }}"
+    deprecated_variable: "keycloak_quarkus_frontend_url" # read in deprecation handler
+  notify:
+    - print deprecation warning
+
+# https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/upgrading_guide/index#new_hostname_options
+- name: Check deprecation of keycloak_quarkus_hostname_strict_https + keycloak_quarkus_host + keycloak_quarkus_port + keycloak_quarkus_path -> keycloak_quarkus_hostname
+  when:
+    - keycloak_quarkus_hostname is not defined
+    - keycloak_quarkus_hostname_strict_https is defined or keycloak_quarkus_frontend_url is defined or keycloak_quarkus_port is defined or keycloak_quarkus_path is defined
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
+  ansible.builtin.set_fact:
+    keycloak_quarkus_hostname: >-
+      {% set protocol = '' %}
+      {% if keycloak_quarkus_hostname_strict_https %}
+        {% set protocol = 'https://' %}
+      {% elif keycloak_quarkus_hostname_strict_https is defined and keycloak_quarkus_hostname_strict_https is False %}
+        {% set protocol = 'http://' %}
+      {% endif %}
+      {{ protocol }}{{ keycloak_quarkus_host }}:{{ keycloak_quarkus_port }}/{{ keycloak_quarkus_path }}
+    deprecated_variable: "keycloak_quarkus_hostname_strict_https or keycloak_quarkus_frontend_url or keycloak_quarkus_frontend_url or keycloak_quarkus_hostname" # read in deprecation handler
+  notify:
+    - print deprecation warning
+
+# https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/upgrading_guide/index#new_hostname_options
+- name: Check deprecation of keycloak_quarkus_admin_url -> keycloak_quarkus_admin
+  when:
+    - keycloak_quarkus_admin is not defined
+    - keycloak_quarkus_admin_url is defined
+    - keycloak_quarkus_admin_url != ''
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
+  ansible.builtin.set_fact:
+    keycloak_quarkus_admin: "{{ keycloak_quarkus_admin_url }}"
+    deprecated_variable: "keycloak_quarkus_admin_url" # read in deprecation handler
+  notify:
+    - print deprecation warning
+
+# https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/upgrading_guide/index#new_hostname_options
+- name: Check deprecation of keycloak_quarkus_hostname_strict_backchannel -> keycloak_quarkus_hostname_backchannel_dynamic
+  when:
+    - keycloak_quarkus_hostname_backchannel_dynamic is not defined
+    - keycloak_quarkus_hostname_strict_backchannel is defined
+    - keycloak_quarkus_hostname_strict_backchannel != ''
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
+  ansible.builtin.set_fact:
+    keycloak_quarkus_hostname_backchannel_dynamic: "{{ keycloak_quarkus_hostname_strict_backchannel == False }}"
+    deprecated_variable: "keycloak_quarkus_hostname_backchannel_dynamic" # read in deprecation handler
+  notify:
+    - print deprecation warning
+
+# https://github.com/keycloak/keycloak/issues/30009
+- name: Check deprecation of keycloak_quarkus_admin_user -> keycloak_quarkus_bootstrap_admin_user
+  when:
+    - keycloak_quarkus_bootstrap_admin_user is not defined
+    - keycloak_quarkus_admin_user is defined
+    - keycloak_quarkus_admin_user != ''
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
+  ansible.builtin.set_fact:
+    keycloak_quarkus_bootstrap_admin_user: "{{ keycloak_quarkus_admin_user }}"
+    deprecated_variable: "keycloak_quarkus_admin_user" # read in deprecation handler
+  notify:
+    - print deprecation warning
+
+# https://github.com/keycloak/keycloak/issues/30009
+- name: Check deprecation of keycloak_quarkus_admin_pass -> keycloak_quarkus_bootstrap_admin_password
+  when:
+    - keycloak_quarkus_bootstrap_admin_password is not defined
+    - keycloak_quarkus_admin_pass is defined
+    - keycloak_quarkus_admin_pass != ''
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
+  ansible.builtin.set_fact:
+    keycloak_quarkus_bootstrap_admin_user: "{{ keycloak_quarkus_admin_pass }}"
+    deprecated_variable: "keycloak_quarkus_admin_pass" # read in deprecation handler
+  notify:
+    - print deprecation warning
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/keycloak_quarkus/tasks/firewalld.yml
+++ b/roles/keycloak_quarkus/tasks/firewalld.yml
@@ -12,7 +12,7 @@
     enabled: true
     state: started
 
-- name: "Configure firewall for {{ keycloak.service_name }} ports"
+- name: "Configure firewall for {{ keycloak.service_name }} http port"
   become: true
   ansible.posix.firewalld:
     port: "{{ item }}"
@@ -21,5 +21,16 @@
     immediate: true
   loop:
     - "{{ keycloak_quarkus_http_port }}/tcp"
+  when: keycloak_quarkus_http_enabled | bool
+
+- name: "Configure firewall for {{ keycloak.service_name }} ports"
+  become: true
+  ansible.posix.firewalld:
+    port: "{{ item }}"
+    permanent: true
+    state: enabled
+    immediate: true
+  loop:
     - "{{ keycloak_quarkus_https_port }}/tcp"
+    - "{{ keycloak_quarkus_http_management_port }}/tcp"
     - "{{ keycloak_quarkus_jgroups_port }}/tcp"

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -91,7 +91,7 @@
   register: keycloak_service_status
   changed_when: false
 
-- name: "Notify to remove `keycloak_quarkus_admin_user[_pass]` env vars"
+- name: "Notify to remove `keycloak_quarkus_bootstrap_admin_user[_password]` env vars"
   when:
     - not ansible_local.keycloak.general.bootstrapped | default(false) | bool # it was not bootstrapped prior to the current role's execution
     - keycloak_service_status.status.ActiveState == "active"                  # but it is now

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -7,13 +7,22 @@
     fail_msg: "The console administrator password is empty or invalid. Please set the keycloak_quarkus_bootstrap_admin_password to a 12+ char long string"
     success_msg: "{{ 'Console administrator password OK' }}"
 
-- name: Validate relative path
+- name: Validate http_relative_path
   ansible.builtin.assert:
     that:
       - keycloak_quarkus_http_relative_path is regex('^/.*')
     quiet: true
     fail_msg: "The relative path for keycloak_quarkus_http_relative_path must begin with /"
     success_msg: "{{ 'Relative path OK' }}"
+
+- name: Validate http_management_relative_path
+  ansible.builtin.assert:
+    that:
+      - keycloak_quarkus_http_management_relative_path is regex('^/.*')
+    quiet: true
+    fail_msg: "The relative path for keycloak_quarkus_http_management_relative_path must begin with /"
+    success_msg: "{{ 'Relative mgmt path OK' }}"
+  when: keycloak_quarkus_http_management_relative_path is defined
 
 - name: Validate configuration
   ansible.builtin.assert:

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -2,9 +2,9 @@
 - name: Validate admin console password
   ansible.builtin.assert:
     that:
-      - keycloak_quarkus_admin_pass | length > 12
+      - keycloak_quarkus_bootstrap_admin_password | length > 12
     quiet: true
-    fail_msg: "The console administrator password is empty or invalid. Please set the keycloak_quarkus_admin_pass to a 12+ char long string"
+    fail_msg: "The console administrator password is empty or invalid. Please set the keycloak_quarkus_bootstrap_admin_password to a 12+ char long string"
     success_msg: "{{ 'Console administrator password OK' }}"
 
 - name: Validate relative path

--- a/roles/keycloak_quarkus/templates/cache-ispn.xml.j2
+++ b/roles/keycloak_quarkus/templates/cache-ispn.xml.j2
@@ -18,8 +18,8 @@
 
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:14.0 http://www.infinispan.org/schemas/infinispan-config-14.0.xsd"
-        xmlns="urn:infinispan:config:14.0">
+        xsi:schemaLocation="urn:infinispan:config:15.0 http://www.infinispan.org/schemas/infinispan-config-15.0.xsd"
+        xmlns="urn:infinispan:config:15.0">
 
 {% set stack_expression='' %}
 {% if keycloak_quarkus_ha_enabled and keycloak_quarkus_ha_discovery == 'TCPPING' %}
@@ -55,18 +55,22 @@
         </local-cache>
         <distributed-cache name="sessions" owners="2">
             <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
         </distributed-cache>
         <distributed-cache name="authenticationSessions" owners="2">
             <expiration lifespan="-1"/>
         </distributed-cache>
         <distributed-cache name="offlineSessions" owners="2">
             <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
         </distributed-cache>
         <distributed-cache name="clientSessions" owners="2">
             <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
         </distributed-cache>
         <distributed-cache name="offlineClientSessions" owners="2">
             <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
         </distributed-cache>
         <distributed-cache name="loginFailures" owners="2">
             <expiration lifespan="-1"/>

--- a/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
+++ b/roles/keycloak_quarkus/templates/keycloak-sysconfig.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 {% if not ansible_local.keycloak.general.bootstrapped | default(false) | bool %}
-KEYCLOAK_ADMIN={{ keycloak_quarkus_admin_user }}
-KEYCLOAK_ADMIN_PASSWORD='{{ keycloak_quarkus_admin_pass }}'
+KC_BOOTSTRAP_ADMIN_USERNAME={{ keycloak_quarkus_bootstrap_admin_user }}
+KC_BOOTSTRAP_ADMIN_PASSWORD='{{ keycloak_quarkus_bootstrap_admin_password }}'
 {% else %}
 {{ keycloak.bootstrap_mnemonic }}
 {% endif %}

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -21,7 +21,6 @@ hostname-strict-https=false
 # Config store
 config-keystore={{ keycloak_quarkus_config_key_store_file }}
 config-keystore-password={{ keycloak_quarkus_config_key_store_password }}
-config-keystore-type=PKCS12
 {% endif %}
 
 # Observability

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -22,8 +22,16 @@ health-enabled={{ keycloak_quarkus_health_enabled | lower }}
 
 # HTTP
 http-enabled={{ keycloak_quarkus_http_enabled | lower }}
+{% if keycloak_quarkus_http_enabled %}
 http-port={{ keycloak_quarkus_http_port }}
+{% endif %}
 http-relative-path={{ keycloak_quarkus_http_relative_path }}
+
+# Management
+http-management-port={{ keycloak_quarkus_http_management_port }}
+{% if keycloak_quarkus_http_management_relative_path is defined and keycloak_quarkus_http_management_relative_path | length > 0 %}
+http-management-relative-path={{ keycloak_quarkus_http_management_relative_path }}
+{% endif %}
 
 # HTTPS
 https-port={{ keycloak_quarkus_https_port }}

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -10,13 +10,6 @@ db-password={{ keycloak_quarkus_db_pass }}
 {% endif %}
 {% endif %}
 
-{% if keycloak_quarkus_hostname_strict_https is defined and keycloak_quarkus_hostname_strict_https is sameas true -%}
-hostname-strict-https=true
-{% endif -%}
-{% if keycloak_quarkus_hostname_strict_https is defined and keycloak_quarkus_hostname_strict_https is sameas false -%}
-hostname-strict-https=false
-{% endif -%}
-
 {% if keycloak.config_key_store_enabled %}
 # Config store
 config-keystore={{ keycloak_quarkus_config_key_store_file }}
@@ -48,16 +41,10 @@ https-trust-store-password={{ keycloak_quarkus_https_trust_store_password }}
 {% endif %}
 
 # Client URL configuration
-{% if keycloak_quarkus_frontend_url %}
-hostname-url={{ keycloak_quarkus_frontend_url }}
-{% else %}
-hostname={{ keycloak_quarkus_host }}
-hostname-port={{ keycloak_quarkus_port }}
-hostname-path={{ keycloak_quarkus_path }}
-{% endif %}
-hostname-admin-url={{ keycloak_quarkus_admin_url }}
+hostname={{ keycloak_quarkus_hostname }}
+hostname-admin={{ keycloak_quarkus_admin }}
 hostname-strict={{ keycloak_quarkus_hostname_strict | lower }}
-hostname-strict-backchannel={{ keycloak_quarkus_hostname_strict_backchannel | lower }}
+hostname-backchannel-dynamic={{ keycloak_quarkus_hostname_backchannel_dynamic | lower }}
 
 # Cluster
 {% if keycloak_quarkus_ha_enabled %}

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -4,8 +4,7 @@ keycloak: # noqa var-naming this is an internal dict of interpolated values
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "{{ keycloak_quarkus_hostname }}{{ keycloak_quarkus_http_relative_path }}{{ '/' \
-               if keycloak_quarkus_http_relative_path | length > 1 else '' }}{{ keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration') }}"
+  health_url: "{{ keycloak_quarkus_health_check_url | default(keycloak_quarkus_hostname + '/' + (keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration'))) }}"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"
   service_group: "{{ keycloak_quarkus_service_group }}"

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -4,7 +4,7 @@ keycloak: # noqa var-naming this is an internal dict of interpolated values
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "{{ 'https' if keycloak_quarkus_http_enabled == False else 'http' }}://{{ keycloak_quarkus_host }}:{{ keycloak_quarkus_https_port if keycloak_quarkus_http_enabled == False else keycloak_quarkus_http_port }}{{ keycloak_quarkus_http_relative_path }}{{ '/' \
+  health_url: "{{ keycloak_quarkus_hostname }}{{ keycloak_quarkus_http_relative_path }}{{ '/' \
                if keycloak_quarkus_http_relative_path | length > 1 else '' }}{{ keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration') }}"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -4,7 +4,7 @@ keycloak: # noqa var-naming this is an internal dict of interpolated values
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "{{ keycloak_quarkus_health_check_url | default(keycloak_quarkus_hostname + '/' + (keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration'))) }}"
+  health_url: "{{ keycloak_quarkus_health_check_url | default(keycloak_quarkus_hostname ~ '/' ~ (keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration'))) }}"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"
   service_group: "{{ keycloak_quarkus_service_group }}"

--- a/roles/keycloak_quarkus/vars/redhat.yml
+++ b/roles/keycloak_quarkus/vars/redhat.yml
@@ -1,5 +1,5 @@
 ---
-keycloak_quarkus_varjvm_package: "{{ keycloak_quarkus_jvm_package | default('java-17-openjdk-headless') }}"
+keycloak_quarkus_varjvm_package: "{{ keycloak_quarkus_jvm_package | default('java-21-openjdk-headless') }}"
 keycloak_quarkus_prereq_package_list:
       - "{{ keycloak_quarkus_varjvm_package }}"
       - unzip


### PR DESCRIPTION
# keycloak_quarkus 3.0+ role migration / porting guide

The support for keycloak 26+ brings breaking changes to the collection role; manual configuration changes to existing playbooks MUST be performed to continue to use the role and update to keycloak 26+.

Important Docs:

* [Upgrade guide](https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/upgrading_guide/index)
* [Supported Configurations](https://access.redhat.com/articles/7033107)

## Important Notes

The following shows some **highlights** of changes you MUST perform; still, read the whole document prior filing any issues

### Hostname v2 & Backchannel setting

Example from <https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/upgrading_guide/index#examples>:

```shell
# Hostname v1
bin/kc.[sh|bat] start --hostname=mykeycloak.org --https-port=8543 --hostname-path=/auth --hostname-strict-https=true --hostname-strict-backchannel=true

# Hostname v2
bin/kc.[sh|bat] start --hostname=https://mykeycloak.org:8543/auth --hostname-backchannel-dynamic=false
```

### Health Checks

Health Check semantics were changed in KC26, consider the following example (depending on your config)

* ~~pre-KC26: http://$SERVER:9990/auth/health/ready~~
* KC26: http**s**://$SERVER:**9000**/auth/health/ready

I.e., the health checks, priorly exposed on all interfaces, now uses https and is exposed solely on the management interface (`keycloak_quarkus_http_management_port`, port `9000` by default); `keycloak_quarkus_http_management_relative_path` is set to `/auth` in this example

## Example Upgrade

Given the above, the changes for this role for upgrading to v3 of this role look as follows:

```diff
 - name: Include keycloak role for RHBK
    ansible.builtin.include_role:
      name: middleware_automation.keycloak.keycloak_quarkus
    vars:
... 
-      keycloak_quarkus_admin_user: "{{ rhbk_admin_user }}"
-      keycloak_quarkus_admin_pass: "{{ rhbk_admin_password }}"
+      keycloak_quarkus_bootstrap_admin_user: "{{ rhbk_admin_user }}"
+      keycloak_quarkus_bootstrap_admin_password: "{{ rhbk_admin_password }}"

-      keycloak_quarkus_host: mykeycloak.org
-      keycloak_quarkus_port: 8543
-      keycloak_quarkus_path: /auth
-      keycloak_quarkus_frontend_url: https://mykeycloak.org:8543/auth/
+      keycloak_quarkus_hostname: https://mykeycloak.org:8543/auth
-      keycloak_quarkus_admin_url: https://admin.mykeycloak.internal:8444/
+      keycloak_quarkus_admin: https://admin.mykeycloak.internal:8444/

-      keycloak_quarkus_hostname_strict_backchannel: false
+      keycloak_quarkus_hostname_backchannel_dynamic: true
```

## Removed/Deprecated Arguments

Most changes happened due to the according changes in [upstream](https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html-single/upgrading_guide/index#server_configuration_changes)

| Name                                           | Replacement (might require manual adaptation)   | Reason                                                                                               |
| ---------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| `keycloak_quarkus_admin_user`                  | `keycloak_quarkus_bootstrap_admin_user`         |                                                                                                      |
| `keycloak_quarkus_admin_pass`                  | `keycloak_quarkus_bootstrap_admin_password`     |                                                                                                      |
| `keycloak_quarkus_host`                        | `keycloak_quarkus_hostname`                     | Deprecated via [hostname v2](https://www.keycloak.org/server/hostname) schema introduction in KC v26 |
| `keycloak_quarkus_port`                        | `keycloak_quarkus_hostname`                     | Deprecated via [hostname v2](https://www.keycloak.org/server/hostname) schema introduction in KC v26 |
| `keycloak_quarkus_path`                        | `keycloak_quarkus_hostname`                     | Deprecated via [hostname v2](https://www.keycloak.org/server/hostname) schema introduction in KC v26 |
| `keycloak_quarkus_frontend_url`                | `keycloak_quarkus_hostname`                     | Deprecated via [hostname v2](https://www.keycloak.org/server/hostname) schema introduction in KC v26 |
| `keycloak_quarkus_admin_url`                   | `keycloak_quarkus_admin`                        | Deprecated via [hostname v2](https://www.keycloak.org/server/hostname) schema introduction in KC v26 |
| `keycloak_quarkus_hostname_strict_backchannel` | `keycloak_quarkus_hostname_backchannel_dynamic` | Deprecated, use (the **inverted**!) `keycloak_quarkus_hostname_backchannel_dynamic` instead.         |

## Newly added Arguments and important changes to already existing ones

| Name                                             | Description                                                                                                                                                                                                                                                         | Default Value |
| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
| `keycloak_quarkus_bootstrap_admin_user`          |                                                                                                                                                                                                                                                                     |               |
| `keycloak_quarkus_bootstrap_admin_password`      |                                                                                                                                                                                                                                                                     |               |
| `keycloak_quarkus_http_management_port`          | Port of the management interface. Relevant only when something is exposed on the management interface - see the guide for details.                                                                                                                                  | `9000`        |
| `keycloak_quarkus_hostname`                      | Address at which is the server exposed. Can be a full URL, or just a hostname. When only hostname is provided, scheme, port and context path are resolved from the request.                                                                                         |               |
| `keycloak_quarkus_http_management_relative_path` | Set the path relative to / for serving resources from management interface. The path must start with a /. If not given, the value is inherited from HTTP options. Relevant only when something is exposed on the management interface - see the guide for details.  | `/`           |
| `keycloak_quarkus_admin`                         | Set the base URL for accessing the *administration console*, including scheme, host, port and path                                                                                                                                                                  |               |
| `keycloak_quarkus_health_check_url`              | Full URL (including scheme, host, path, fragment etc.) used for health check endpoint; `keycloak_quarkus_hostname` will NOT be prepended; helpful when health checks should happen against http port, but `keycloak_quarkus_hostname` uses https scheme per default | ``            |
| `keycloak_quarkus_hostname_backchannel_dynamic`  | Enables dynamic resolving of backchannel URLs, including hostname, scheme, port and context path. Set to true if your application accesses Keycloak via a private network. If set to true, hostname option needs to be specified as a full URL.                     | `false`       |
| `keycloak_quarkus_health_enabled`                | If the server should expose health check endpoints **on the management interface**                                                                                                                                                                                  | `True`        |


