### PR TITLE
Skip certificate checking

### DIFF
--- a/roles/keycloak_realm/tasks/main.yml
+++ b/roles/keycloak_realm/tasks/main.yml
@@ -15,6 +15,7 @@
   ansible.builtin.uri:
     url: "{{ keycloak_url }}{{ keycloak_context }}/admin/realms/{{ keycloak_realm }}"
     method: GET
+    validate_certs: false
     status_code:
       - 200
       - 404

--- a/roles/keycloak_realm/tasks/manage_user_client_roles.yml
+++ b/roles/keycloak_realm/tasks/manage_user_client_roles.yml
@@ -3,6 +3,7 @@
   ansible.builtin.uri:
     url: "{{ keycloak_url }}{{ keycloak_context }}/admin/realms/{{ client_role.realm | default(keycloak_realm) }}"
     method: GET
+    validate_certs: false
     status_code:
       - 200
     headers:
@@ -16,6 +17,7 @@
           default(keycloak_realm) }}/users/{{ (keycloak_user.json | first).id }}/role-mappings/clients/{{ (create_client_result.results | \
           selectattr('end_state.clientId', 'equalto', client_role.client) | list | first).end_state.id }}/available"
     method: GET
+    validate_certs: false
     status_code:
       - 200
     headers:


### PR DESCRIPTION
See #256.
Most, but not all steps in the `keycloak_realm` tasks skip checking SSL certificates.

Since e.g. in `roles/keycloak_realm/tasks/main.yml` the first step `Generate keycloak auth token` has set
 `validate_certs: false`, but the next step `Determine if realm exists` does not, I assume this was a mistake?
 
 I briefly checked the other tasks in `roles/keycloak_realm/tasks/` and added `validate_certs: false` where it was missing.
 With those changes, the tasks now work for my setup with self-signed certificates.