### PR TITLE
Bump major and ansible-core versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ virtualenv $PATH_TO_DEV_VIRTUALENV
 # activate the virtual env
 source $PATH_TO_DEV_VIRTUALENV/bin/activate
 # install ansible and tools onto the virtualenv
-pip install yamllint 'molecule>=6.0' 'molecule-plugins[docker]' 'ansible-core>=2.15' ansible-lint
+pip install yamllint 'molecule>=6.0' 'molecule-plugins[docker]' 'ansible-core>=2.16' ansible-lint
 # install collection dependencies
 ansible-galaxy collection install -r requirements.yml
 # install python dependencies

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Collection to install and configure [Keycloak](https://www.keycloak.org/) or [Re
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15.0**.
+This collection has been tested against following Ansible versions: **>=2.16.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions. A collection may contain metadata that identifies these versions.
 <!--end requires_ansible-->

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 antsibull>=0.17.0
 antsibull-docs
 antsibull-changelog
-ansible-core>=2.14.1
+ansible-core>=2.16.0
 ansible-pygments
 sphinx-rtd-theme
 git+https://github.com/felixfontein/ansible-basic-sphinx-ext

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: middleware_automation
 name: keycloak
-version: "2.4.4"
+version: "3.0.0"
 readme: README.md
 authors:
   - Romain Pelisse <rpelisse@redhat.com>

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"

--- a/molecule/https_revproxy/molecule.yml
+++ b/molecule/https_revproxy/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"
@@ -14,7 +14,7 @@ platforms:
     published_ports:
       - 0.0.0.0:8080:8080/tcp
   - name: proxy
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"

--- a/molecule/overridexml/molecule.yml
+++ b/molecule/overridexml/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"

--- a/molecule/quarkus-devmode/molecule.yml
+++ b/molecule/quarkus-devmode/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -22,6 +22,7 @@
     keycloak_quarkus_systemd_wait_for_timeout: 20
     keycloak_quarkus_systemd_wait_for_delay: 2
     keycloak_quarkus_systemd_wait_for_log: true
+    keycloak_quarkus_restart_health_check: false # would fail because of self-signed cert
     keycloak_quarkus_providers:
       - id: http-client
         spi: connections

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -52,7 +52,7 @@
   roles:
     - role: keycloak_quarkus
     - role: keycloak_realm
-      keycloak_url: "{{ keycloak_quarkus_hostname }}"
+      keycloak_url: http://instance:8080
       keycloak_context: ''
       keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
       keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"

--- a/molecule/quarkus/molecule.yml
+++ b/molecule/quarkus/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
     pre_build_image: true
     privileged: true
     command: "/usr/sbin/init"

--- a/molecule/quarkus/molecule.yml
+++ b/molecule/quarkus/molecule.yml
@@ -31,6 +31,7 @@ provisioner:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
     ANSIBLE_FORCE_COLOR: "true"
+    PYTHONHTTPSVERIFY: 0
 verifier:
   name: ansible
 scenario:

--- a/molecule/quarkus/verify.yml
+++ b/molecule/quarkus/verify.yml
@@ -102,8 +102,8 @@
     - name: "Get Clients"
       ansible.builtin.uri:
         url: "https://instance:8443/admin/realms/TestRealm/clients"
+        validate_certs: false
         headers:
-          validate_certs: false
           Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
       register: keycloak_clients
 
@@ -114,15 +114,15 @@
     - name: "Get Client {{ keycloak_client_uuid }}"
       ansible.builtin.uri:
         url: "https://instance:8443/admin/realms/TestRealm/clients/{{ keycloak_client_uuid }}"
+        validate_certs: false
         headers:
-          validate_certs: false
           Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
       register: keycloak_test_client
 
     - name: "Get Client roles"
       ansible.builtin.uri:
         url: "https://instance:8443/admin/realms/TestRealm/clients/{{ keycloak_client_uuid }}/roles"
+        validate_certs: false
         headers:
-          validate_certs: false
           Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
       register: keycloak_test_client_roles

--- a/molecule/quarkus_ha/molecule.yml
+++ b/molecule/quarkus_ha/molecule.yml
@@ -65,6 +65,7 @@ provisioner:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   env:
     ANSIBLE_FORCE_COLOR: "true"
+    PYTHONHTTPSVERIFY: 0
 verifier:
   name: ansible
 scenario:

--- a/roles/keycloak/meta/main.yml
+++ b/roles/keycloak/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: "2.15"
+  min_ansible_version: "2.16"
 
   platforms:
     - name: EL

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -112,7 +112,7 @@ Role Defaults
 |`keycloak_quarkus_restart_strategy`| Strategy task file for restarting in HA (one of provided restart/['serial.yml','none.yml','serial_then_parallel.yml']) or path to file when providing custom strategy | `restart/serial.yml` |
 |`keycloak_quarkus_restart_health_check`| Whether to wait for successful health check after restart | `true` |
 |`keycloak_quarkus_restart_health_check_delay`| Seconds to let pass before starting healch checks | `10` |
-|`keycloak_quarkus_restart_health_check_reries`| Number of attempts for successful health check before failing | `25` |
+|`keycloak_quarkus_restart_health_check_retries`| Number of attempts for successful health check before failing | `25` |
 |`keycloak_quarkus_restart_pause`| Seconds to wait between restarts in HA strategy | `15` |
 
 

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -163,5 +163,5 @@ keycloak_quarkus_supported_policy_types: ['password-blacklists']
 keycloak_quarkus_restart_strategy: restart/serial.yml
 keycloak_quarkus_restart_health_check: true
 keycloak_quarkus_restart_health_check_delay: 10
-keycloak_quarkus_restart_health_check_reries: 25
+keycloak_quarkus_restart_health_check_retries: 25
 keycloak_quarkus_restart_pause: 15

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -464,7 +464,7 @@ argument_specs:
                 description: "Seconds to let pass before starting healch checks"
                 default: 10
                 type: 'int'
-            keycloak_quarkus_restart_health_check_reries:
+            keycloak_quarkus_restart_health_check_retries:
                 description: "Number of attempts for successful health check before failing"
                 default: 25
                 type: 'int'

--- a/roles/keycloak_quarkus/meta/main.yml
+++ b/roles/keycloak_quarkus/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: "2.15"
+  min_ansible_version: "2.16"
 
   platforms:
     - name: EL

--- a/roles/keycloak_quarkus/tasks/restart.yml
+++ b/roles/keycloak_quarkus/tasks/restart.yml
@@ -12,7 +12,7 @@
     url: "{{ keycloak.health_url }}"
   register: keycloak_status
   until: keycloak_status.status == 200
-  retries: "{{ keycloak_quarkus_restart_health_check_reries }}"
+  retries: "{{ keycloak_quarkus_restart_health_check_retries }}"
   delay: "{{ keycloak_quarkus_restart_health_check_delay }}"
   when: internal_force_health_check | default(keycloak_quarkus_restart_health_check)
 

--- a/roles/keycloak_quarkus/tasks/start.yml
+++ b/roles/keycloak_quarkus/tasks/start.yml
@@ -14,3 +14,4 @@
   until: keycloak_status.status == 200
   retries: 25
   delay: 10
+  when: internal_force_health_check | default(keycloak_quarkus_restart_health_check)

--- a/roles/keycloak_realm/meta/main.yml
+++ b/roles/keycloak_realm/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: "2.15"
+  min_ansible_version: "2.16"
 
   platforms:
     - name: EL


### PR DESCRIPTION
Start collection version 3.0
Update minimum ansible-core requirement to 2.16+
Fix spell in parameter `keycloak_quarkus_restart_health_check_retries`