### PR TITLE
keycloak_realm: change url variables to defaults

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -118,3 +118,7 @@ keycloak_no_log: true
 
 ### logging configuration
 keycloak_log_target: /var/log/keycloak
+
+# locations
+keycloak_url: "http://{{ keycloak_host }}:{{ keycloak_http_port + keycloak_jboss_port_offset }}"
+keycloak_management_url: "http://{{ keycloak_host }}:{{ keycloak_management_http_port + keycloak_jboss_port_offset }}"

--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -1,9 +1,6 @@
 ---
 # internal variables below
 
-# locations
-keycloak_url: "http://{{ keycloak_host }}:{{ keycloak_http_port + keycloak_jboss_port_offset }}"
-keycloak_management_url: "http://{{ keycloak_host }}:{{ keycloak_management_http_port + keycloak_jboss_port_offset }}"
 
 
 keycloak:

--- a/roles/keycloak_realm/defaults/main.yml
+++ b/roles/keycloak_realm/defaults/main.yml
@@ -54,3 +54,7 @@ keycloak_client_users: []
 
 ### List of Keycloak User Federation
 keycloak_user_federation: []
+
+# other settings
+keycloak_url: "http://{{ keycloak_host }}:{{ keycloak_http_port + (keycloak_jboss_port_offset | default(0)) }}"
+keycloak_management_url: "http://{{ keycloak_host }}:{{ keycloak_management_http_port + (keycloak_jboss_port_offset | default(0)) }}"

--- a/roles/keycloak_realm/vars/main.yml
+++ b/roles/keycloak_realm/vars/main.yml
@@ -3,7 +3,3 @@
 
 # name of the realm to create, this is a required variable
 keycloak_realm:
-
-# other settings
-keycloak_url: "http://{{ keycloak_host }}:{{ keycloak_http_port + (keycloak_jboss_port_offset | default(0)) }}"
-keycloak_management_url: "http://{{ keycloak_host }}:{{ keycloak_management_http_port + (keycloak_jboss_port_offset | default(0)) }}"


### PR DESCRIPTION
Role parameters `keycloak_url` and `keycloak_management_url`, formerly variables, are turned into default to make overriding them easier. Default values are unchanged.


Issue: https://issues.redhat.com/browse/AMW-384
GitHub Issue: https://github.com/ansible-middleware/keycloak/issues/265