### PR TITLE
Update example playbooks to use new `bootstrap` var

### DIFF
--- a/playbooks/keycloak_quarkus.yml
+++ b/playbooks/keycloak_quarkus.yml
@@ -2,7 +2,7 @@
 - name: Playbook for Keycloak X Hosts with HTTPS enabled
   hosts: all
   vars:
-    keycloak_quarkus_admin_pass: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_hostname: http://localhost
     keycloak_quarkus_port: 8443
     keycloak_quarkus_log: file

--- a/playbooks/keycloak_quarkus_dev.yml
+++ b/playbooks/keycloak_quarkus_dev.yml
@@ -2,7 +2,7 @@
 - name: Playbook for Keycloak X Hosts in develop mode
   hosts: all
   vars:
-    keycloak_admin_password: "remembertochangeme"
+    keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_hostname: http://localhost
     keycloak_quarkus_port: 8080
     keycloak_quarkus_log: file


### PR DESCRIPTION
When running the quarkus role using the example provided in the repo, it fails with:

```
TASK [middleware_automation.keycloak.keycloak_quarkus : Validating arguments against arg spec 'main'] *********************************************************************************************************************
fatal: [91.99.14.247]: FAILED! => {"argument_errors": ["argument 'keycloak_quarkus_bootstrap_admin_password' is of type <class 'NoneType'> and we were unable to convert to str:
```

This replaces the deprecated `keycloak_admin_password` with `keycloak_quarkus_bootstrap_admin_password`.