### PR TITLE
Rename and honour parameter `keycloak_quarkus_http_host`

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -46,7 +46,7 @@ Role Defaults
 |:---------|:------------|:--------|
 |`keycloak_quarkus_bootstrap_admin_user`| Administration console user account | `admin` |
 |`keycloak_quarkus_admin_user`| Deprecated, use `keycloak_quarkus_bootstrap_admin_user` instead. | |
-|`keycloak_quarkus_bind_address`| Address for binding service ports | `0.0.0.0` |
+|`keycloak_quarkus_bind_address`| Deprecated, use `keycloak_quarkus_http_host` instead |  `0.0.0.0` |
 |`keycloak_quarkus_host`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
 |`keycloak_quarkus_port`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
 |`keycloak_quarkus_path`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
@@ -107,6 +107,7 @@ Role Defaults
 | Variable | Description | Default |
 |:---------|:------------|:--------|
 |`keycloak_quarkus_http_relative_path`| Set the path relative to / for serving resources. The path must start with a / | `/` |
+|`keycloak_quarkus_http_host`| The http host, ie. the address used to bind the service |  `0.0.0.0` |
 |`keycloak_quarkus_http_port`| HTTP listening port | `8080` |
 |`keycloak_quarkus_https_port`| TLS HTTP listening port | `8443` |
 |`keycloak_quarkus_http_management_port`| Port of the management interface. Relevant only when something is exposed on the management interface - see the guide for details. | `9000` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -32,7 +32,8 @@ keycloak_quarkus_bootstrap_admin_password:
 keycloak_quarkus_master_realm: master
 
 ### Configuration settings
-keycloak_quarkus_bind_address: 0.0.0.0
+keycloak_quarkus_bind_address: 0.0.0.0 # deprecated use keycloak_quarkus_http_host
+keycloak_quarkus_http_host: 0.0.0.0
 keycloak_quarkus_http_enabled: true
 keycloak_quarkus_http_port: 8080
 keycloak_quarkus_https_port: 8443

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -82,7 +82,7 @@ argument_specs:
                 type: "str"
             keycloak_quarkus_bind_address:
                 default: "0.0.0.0"
-                description: "Address for binding service ports"
+                description: "Deprecated, use `keycloak_quarkus_http_host`"
                 type: "str"
             keycloak_quarkus_hostname:
                 description: >-
@@ -102,6 +102,10 @@ argument_specs:
                 default: true
                 description: "Enable listener on HTTP port"
                 type: "bool"
+            keycloak_quarkus_http_host:
+                default: '0.0.0.0'
+                description: "HTTP host, address for binding service ports"
+                type: "str"
             keycloak_quarkus_http_port:
                 default: 8080
                 description: "HTTP port"

--- a/roles/keycloak_quarkus/tasks/deprecations.yml
+++ b/roles/keycloak_quarkus/tasks/deprecations.yml
@@ -145,5 +145,18 @@
   notify:
     - print deprecation warning
 
+- name: Check deprecation of keycloak_quarkus_bind_address -> keycloak_quarkus_http_host
+  when:
+    - keycloak_quarkus_bind_address is defined
+    - keycloak_quarkus_bind_address != '0.0.0.0'
+  delegate_to: localhost
+  run_once: true
+  changed_when: keycloak_quarkus_show_deprecation_warnings
+  ansible.builtin.set_fact:
+    keycloak_quarkus_http_host: "{{ keycloak_quarkus_bind_address }}"
+    deprecated_variable: "keycloak_quarkus_bind_address" # read in deprecation handler
+  notify:
+    - print deprecation warning
+  
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/keycloak_quarkus/templates/cache-ispn.xml.j2
+++ b/roles/keycloak_quarkus/templates/cache-ispn.xml.j2
@@ -26,7 +26,7 @@
 {% set stack_expression='stack="tcpping"' %}
     <jgroups>
         <stack name="tcpping" extends="tcp">
-            <!-- <TCP external_addr="${env.KC_EXTERNAL_ADDR}" bind_addr="{{ keycloak_quarkus_bind_address }}" bind_port="{{ keycloak_quarkus_jgroups_port }}" /> -->
+            <!-- <TCP external_addr="${env.KC_EXTERNAL_ADDR}" bind_addr="{{ keycloak_quarkus_http_host }}" bind_port="{{ keycloak_quarkus_jgroups_port }}" /> -->
             <TCPPING
                 initial_hosts="{{ keycloak_quarkus_cluster_nodes | map(attribute='inventory_host') | join (',') }}"
                 port_range="0"

--- a/roles/keycloak_quarkus/templates/keycloak.conf.j2
+++ b/roles/keycloak_quarkus/templates/keycloak.conf.j2
@@ -26,6 +26,7 @@ http-enabled={{ keycloak_quarkus_http_enabled | lower }}
 http-port={{ keycloak_quarkus_http_port }}
 {% endif %}
 http-relative-path={{ keycloak_quarkus_http_relative_path }}
+http-host={{ keycloak_quarkus_http_host }}
 
 # Management
 http-management-port={{ keycloak_quarkus_http_management_port }}


### PR DESCRIPTION
Parameter rename and add in configuration since it was missing:

| Name                                           | Replacement (requires manual adaptation)   | Reason                                                                                               |
| ---------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
| `keycloak_quarkus_bind_address`         | `keycloak_quarkus_http_host`  | [HTTP configuration](https://www.keycloak.org/server/all-config#category-http)  |

`keycloak_quarkus_bind_address` remains as deprecated, when used a deprecation warning will be emitted and the variable will be used.

Labelled as bugfix and not breaking change even if it contains a rename, because the value would not be used when set.

Fix #242