### PR TITLE
New parameter to set the jgroups host IP address

### DIFF
--- a/molecule/debian/prepare.yml
+++ b/molecule/debian/prepare.yml
@@ -10,3 +10,8 @@
           # - openjdk-21-jdk-headless # this is not available in ghcr.io/hspaans/molecule-containers:debian-11 (neither in debian-12) since the images are using outdated package sources
           - openjdk-17-jdk-headless
         state: present
+    - name: "Install iproute2"
+      ansible.builtin.apt:
+        name:
+          - iproute2
+        state: present

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -79,6 +79,7 @@ Role Defaults
 |`keycloak_quarkus_ha_enabled`| Enable auto configuration for database backend, clustering and remote caches on infinispan | `False` |
 |`keycloak_quarkus_ha_discovery`| Discovery protocol for HA cluster members | `TCPPING` |
 |`keycloak_quarkus_db_enabled`| Enable auto configuration for database backend | `True` if `keycloak_quarkus_ha_enabled` is True, else `False` |
+|`keycloak_quarkus_jgroups_ip`| Host jgroups IP.  If changing this variable you must make sure it is always set for all hosts in your cluster. | `{{ ansible_default_ipv4.address }}` |
 |`keycloak_quarkus_jgroups_port`| jgroups cluster tcp port | `7800` |
 |`keycloak_quarkus_systemd_wait_for_port` | Whether systemd unit should wait for keycloak port before returning | `{{ keycloak_quarkus_ha_enabled }}` |
 |`keycloak_quarkus_systemd_wait_for_port_number`| Which port the systemd unit should wait for | `{{ keycloak_quarkus_https_port }}` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -38,6 +38,7 @@ keycloak_quarkus_http_enabled: true
 keycloak_quarkus_http_port: 8080
 keycloak_quarkus_https_port: 8443
 keycloak_quarkus_http_management_port: 9000
+keycloak_quarkus_jgroups_ip: "{{ ansible_default_ipv4.address }}"
 keycloak_quarkus_jgroups_port: 7800
 keycloak_quarkus_java_heap_opts: "-Xms1024m -Xmx2048m"
 keycloak_quarkus_java_jvm_opts: "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -195,6 +195,10 @@ argument_specs:
                 default: 9000
                 description: "Port of the management interface. Relevant only when something is exposed on the management interface - see the guide for details."
                 type: "int"
+            keycloak_quarkus_jgroups_ip:
+                default: "{{ ansible_default_ipv4.address }}"
+                description: Host jgroups IP.  If changing this variable you must make sure it is always set for all hosts in your cluster.
+                type: "str"
             keycloak_quarkus_jgroups_port:
                 default: 7800
                 description: "jgroups cluster tcp port"

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -39,8 +39,8 @@
         {
           "name": item,
           "address": 'jgroups-' + item,
-          "inventory_host": hostvars[item].ansible_default_ipv4.address | default(item) + '[' + (keycloak_quarkus_jgroups_port | string) + ']',
-          "value": hostvars[item].ansible_default_ipv4.address | default(item)
+          "inventory_host": hostvars[item].keycloak_quarkus_jgroups_ip | default(item) + '[' + (keycloak_quarkus_jgroups_port | string) + ']',
+          "value": hostvars[item].keycloak_quarkus_jgroups_ip | default(item)
         }
       ] }}
   loop: "{{ ansible_play_batch }}"


### PR DESCRIPTION
This is useful if the default route does not
represent the network you want/need to use for
cluster communication.