### PR TITLE
Run config rebuild after SPI providers update

### DIFF
--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -236,7 +236,6 @@
   loop: "{{ keycloak_quarkus_providers }}"
   when: item.maven is defined
   no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
-  notify: "{{ ['invalidate keycloak theme cache', 'rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or item.restart else [] }}"
 
 - name: "Copy maven providers"
   ansible.builtin.copy:
@@ -250,6 +249,7 @@
   loop: "{{ keycloak_quarkus_providers }}"
   when: item.maven is defined
   no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
+  notify: "{{ ['invalidate keycloak theme cache', 'rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or item.restart else [] }}"
 
 - name: "Copy local providers"
   ansible.builtin.copy:


### PR DESCRIPTION
26.2 is stricter when it comes to validating its optimized config and thus refuses to start in case a SPI was deployed w/o properly having invoked `kc.sh build` first (related: https://github.com/keycloak/keycloak/issues/37770)