### PR TITLE
Use jdk21 as default in debian

### DIFF
--- a/molecule/debian/molecule.yml
+++ b/molecule/debian/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: ghcr.io/hspaans/molecule-containers:debian-11
+    image: ghcr.io/hspaans/molecule-containers:debian-13
     pre_build_image: true
     privileged: true
     port_bindings:

--- a/molecule/debian/prepare.yml
+++ b/molecule/debian/prepare.yml
@@ -7,11 +7,5 @@
       ansible.builtin.apt:
         name:
           - sudo
-          # - openjdk-21-jdk-headless # this is not available in ghcr.io/hspaans/molecule-containers:debian-11 (neither in debian-12) since the images are using outdated package sources
-          - openjdk-17-jdk-headless
-        state: present
-    - name: "Install iproute2"
-      ansible.builtin.apt:
-        name:
+          - openjdk-21-jdk-headless
           - iproute2
-        state: present

--- a/roles/keycloak_quarkus/vars/debian.yml
+++ b/roles/keycloak_quarkus/vars/debian.yml
@@ -1,5 +1,5 @@
 ---
-keycloak_quarkus_varjvm_package: "{{ keycloak_quarkus_jvm_package | default('openjdk-17-jdk-headless') }}"
+keycloak_quarkus_varjvm_package: "{{ keycloak_quarkus_jvm_package | default('openjdk-21-jdk-headless') }}"
 keycloak_quarkus_prereq_package_list:
       - "{{ keycloak_quarkus_varjvm_package }}"
       - bash


### PR DESCRIPTION
Fix #288 