### PR TITLE
Fix alternate download location being ignored (JBossNeworkAPI always used)

### DIFF
--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -77,6 +77,7 @@
     - not archive_path.stat.exists
     - rhbk_enable is defined and rhbk_enable
     - not keycloak.offline_install
+    - keycloak_quarkus_alternate_download_url is undefined
   block:
     - name: Retrieve product download using JBoss Network API
       middleware_automation.common.product_search:


### PR DESCRIPTION
Even is we set keycloak_quarkus_alternate_download_url previous block was run and we always try to download archive from JBoss Network Api.