### PR TITLE
Added support for copy remote_src function for providers

### DIFF
--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -221,6 +221,7 @@ keycloak_quarkus_providers:
     restart: true                           # optional, whether to rebuild config and restart the service after deploying, default true
     url: https://.../.../custom_spi.jar     # optional, url for download via http
     local_path: my_theme_spi.jar            # optional, path on local controller for SPI to be uploaded
+    remote: true                            # optional, whether to copy from localhost or remotely, see https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html#parameter-remote_src, default false
     maven:                                  # optional, for download using maven
       repository_url: https://maven.pkg.github.com/OWNER/REPOSITORY # optional, maven repo url
       group_id:  my.group                   # optional, maven group id

--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -280,6 +280,7 @@
     owner: "{{ keycloak.service_user }}"
     group: "{{ keycloak.service_group }}"
     mode: '0640'
+    remote_src: "{{ item.remote | default(false) }}"
   become: true
   loop: "{{ keycloak_quarkus_providers }}"
   when: item.local_path is defined


### PR DESCRIPTION
Added remote_src option in install.yml for copying provider files remotely and documented accordingly in readme.