### PR TITLE
keycloak_realm: allow secret in keycloak_clients

### DIFF
--- a/roles/keycloak_realm/README.md
+++ b/roles/keycloak_realm/README.md
@@ -74,6 +74,7 @@ Refer to [docs](https://docs.ansible.com/ansible/latest/collections/community/ge
     - name: <name of the client>
       id: <id of the client>
       client_id: <id of the client>
+      secret: <secret of the client (Optional)>
       roles: <keycloak_client_default_roles>
       realm: <name of the realm that contains the client>
       public_client: <true for public, false for confidential>

--- a/roles/keycloak_realm/tasks/main.yml
+++ b/roles/keycloak_realm/tasks/main.yml
@@ -76,6 +76,7 @@
     default_roles: "{{ item.roles | default(omit) }}"
     client_id: "{{ item.client_id | default(omit) }}"
     id: "{{ item.id | default(omit) }}"
+    secret: "{{ item.secret | default(omit) }}"
     name: "{{ item.name | default(omit) }}"
     description: "{{ item.description | default(omit) }}"
     root_url: "{{ item.root_url | default('') }}"


### PR DESCRIPTION
# Feature

`keycloak_clients` can now configure client secret.

# Example

```yaml
keycloak_clients:
  - name: MyAwesomeClient
    client_id: awesomeclient
    secret: changeme
    realm: "myrealm
```

Fix #301 