### PR TITLE
HTTP relative path not reflected in the health_url

### DIFF
--- a/molecule/https_revproxy/converge.yml
+++ b/molecule/https_revproxy/converge.yml
@@ -11,6 +11,5 @@
     keycloak_quarkus_http_port: 8080
     keycloak_quarkus_proxy_mode: edge
     keycloak_quarkus_http_relative_path: /
-    keycloak_quarkus_health_check_url: http://proxy:8080/realms/master/.well-known/openid-configuration
   roles:
     - role: keycloak_quarkus

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -116,6 +116,8 @@ keycloak_quarkus_spi_sticky_session_encoder_infinispan_should_attach_route: true
 
 keycloak_quarkus_metrics_enabled: false
 keycloak_quarkus_health_enabled: true
+keycloak_quarkus_health_check_url_path: "realms/master/.well-known/openid-configuration"
+keycloak_quarkus_http_health_port: 9000
 
 ### caches; must read: https://www.keycloak.org/2024/12/storing-sessions-in-kc26
 ### embedded caches

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -259,6 +259,10 @@ argument_specs:
                 default: true
                 description: "If the server should expose health check endpoints on the management interface"
                 type: "bool"
+            keycloak_quarkus_http_health_port:
+                default: 9000
+                description: "Port used for the health endpoint when health checks are enabled. This is typically different from the main HTTP port."
+                type: "int"
             keycloak_quarkus_cache_remote:
                 description: "Whether to connect to remote cache infinispan server"
                 default: false

--- a/roles/keycloak_quarkus/tasks/restart.yml
+++ b/roles/keycloak_quarkus/tasks/restart.yml
@@ -7,6 +7,11 @@
     daemon_reload: true
   become: true
 
+- name: "Fail if health check URL does not use port 9000 while health is enabled"
+  ansible.builtin.fail:
+    msg: "When `keycloak_quarkus_health_enabled` is true, the health check URL must use port 9000. Current URL: {{ keycloak_quarkus_health_check_url }}"
+  when: keycloak_quarkus_health_enabled | bool and keycloak_quarkus_health_check_url is defined and (keycloak_quarkus_health_check_url | regex_search(':(\\d+)', '\\1') | int) != 9000
+
 - name: "Wait until {{ keycloak.service_name }} service becomes active {{ keycloak.health_url }}"
   ansible.builtin.uri:
     url: "{{ keycloak.health_url }}"

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -1,10 +1,12 @@
 ---
+keycloak_quarkus_effective_health_path: "{{ 'health/ready' if keycloak_quarkus_health_enabled | bool else keycloak_quarkus_health_check_url_path }}"
+keycloak_quarkus_hostname_stripped: "{{ keycloak_quarkus_hostname | regex_replace('(:\\d+)(?=/|$)', '') }}"
 keycloak: # noqa var-naming this is an internal dict of interpolated values
   home: "{{ keycloak_quarkus_home }}"
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "{{ keycloak_quarkus_health_check_url | default(keycloak_quarkus_hostname ~ '/' ~ (keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration'))) }}"
+  health_url: "{{ keycloak_quarkus_health_check_url | default(((('https://' ~ keycloak_quarkus_hostname_stripped ~ ':' ~ keycloak_quarkus_http_health_port) if not (keycloak_quarkus_hostname.startswith('http://') or keycloak_quarkus_hostname.startswith('https://')) else keycloak_quarkus_hostname_stripped ~ ':' ~ keycloak_quarkus_http_health_port) ~ keycloak_quarkus_http_relative_path ~ keycloak_quarkus_effective_health_path), true) }}"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"
   service_group: "{{ keycloak_quarkus_service_group }}"

--- a/roles/keycloak_realm/README.md
+++ b/roles/keycloak_realm/README.md
@@ -8,20 +8,20 @@ Create realms and clients in [keycloak](https://keycloak.org/) or [Red Hat Singl
 Role Defaults
 -------------
 
-| Variable | Description | Default |
-|:---------|:------------|:--------|
-|`keycloak_admin_user`| Administration console user account | `admin` |
-|`keycloak_host`| hostname | `localhost` |
-|`keycloak_context`| Context path for rest calls | `/auth` |
-|`keycloak_http_port`| HTTP port | `8080` |
-|`keycloak_https_port`| TLS HTTP port | `8443` |
-|`keycloak_auth_realm`| Name of the main authentication realm | `master` |
-|`keycloak_management_http_port`| Management port | `9990` |
-|`keycloak_auth_client`| Authentication client for configuration REST calls | `admin-cli` |
-|`keycloak_client_public`| Configure a public realm client | `True` |
-|`keycloak_client_web_origins`| Web origins for realm client | `/*` |
-|`keycloak_url`| URL for configuration rest calls | `http://{{ keycloak_host }}:{{ keycloak_http_port }}` |
-|`keycloak_management_url`| URL for management console rest calls | `http://{{ keycloak_host }}:{{ keycloak_management_http_port }}` |
+| Variable                            | Description                                                      | Default                                               |
+|:------------------------------------|:-----------------------------------------------------------------|:------------------------------------------------------|
+| `keycloak_admin_user`               | Administration console user account                              | `admin`                                               |
+| `keycloak_host`                     | hostname                                                         | `localhost`                                           |
+| `keycloak_context`                  | Context path for rest calls                                      | `/auth`                                               |
+| `keycloak_http_port`                | HTTP port                                                        | `8080`                                                |
+| `keycloak_https_port`               | TLS HTTP port                                                    | `8443`                                                |
+| `keycloak_auth_realm`               | Name of the main authentication realm                            | `master`                                              |
+| `keycloak_management_http_port`     | Management port                                                  | `9990`                                                |
+| `keycloak_auth_client`              | Authentication client for configuration REST calls               | `admin-cli`                                           |
+| `keycloak_client_public`            | Configure a public realm client                                  | `True`                                                |
+| `keycloak_client_web_origins`       | Web origins for realm client                                     | `/*`                                                  |
+| `keycloak_url`                      | URL for configuration rest calls                                 | `http://{{ keycloak_host }}:{{ keycloak_http_port }}` |
+| `keycloak_quarkus_http_health_port` | Port used for the health endpoint when health checks are enabled | `9000`                                                |
 
 
 Role Variables


### PR DESCRIPTION
Issue: https://github.com/ansible-middleware/keycloak/issues/299