### PR TITLE
manage_client_roles.yml: use "client.id" instead of "client.name" to fix client role creation.

### DIFF
--- a/roles/keycloak_realm/tasks/manage_client_roles.yml
+++ b/roles/keycloak_realm/tasks/manage_client_roles.yml
@@ -2,7 +2,7 @@
   middleware_automation.keycloak.keycloak_role:
     name: "{{ item }}"
     realm: "{{ client.realm | default(keycloak_realm) }}"
-    client_id: "{{ client.name }}"
+    client_id: "{{ client.client_id }}"
     auth_client_id: "{{ keycloak_auth_client }}"
     auth_keycloak_url: "{{ keycloak_url }}{{ keycloak_context }}"
     auth_realm: "{{ keycloak_auth_realm }}"


### PR DESCRIPTION
I faced an issue today that client role could not be added. Turned out that by accident the "client.name" variable was used instead of "client.id" in the task.