### PR TITLE
AMW-518 Validating arguments against arg spec 'main' fails unexpectedly.

### DIFF
--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -199,6 +199,26 @@ argument_specs:
                 default: 9000
                 description: "Port of the management interface. Relevant only when something is exposed on the management interface - see the guide for details."
                 type: "int"
+            keycloak_quarkus_jgroups_port:
+                description: 'jgroups bind port'
+                default: 7800
+                type: "int"
+            keycloak_quarkus_jgroups_bind_address:
+                description: 'jgroups bind address'
+                default: "{{ ansible_default_ipv4.address }}"
+                type: "str"
+            keycloak_quarkus_jgroups_external_addr:
+                description: 'IP address that other instances in the Keycloak should use to contact this node'
+                default: "{{ keycloak_quarkus_jgroups_bind_address }}"
+                type: "str"
+            keycloak_quarkus_jgroups_external_port:
+                description: 'Port that other instances in the Keycloak cluster should use to contact this node'
+                default: "{{ keycloak_quarkus_jgroups_port }}"
+                type: "int"
+            keycloak_quarkus_jgroups_opts:
+                description: "JVM arguments for jgroups configuration"
+                default: "-Djgroups.bind.address={{ keycloak_quarkus_jgroups_bind_address }} -Djgroups.external_port={{ keycloak_quarkus_jgroups_external_port }} -Djgroups.external_addr={{ keycloak_quarkus_jgroups_external_addr }}"
+                type: "str"
             keycloak_quarkus_java_heap_opts:
                 default: "-Xms1024m -Xmx2048m"
                 description: "Heap memory JVM setting"
@@ -475,26 +495,6 @@ argument_specs:
             keycloak_quarkus_download_path:
                 description: "Path local to controller for offline/download of install archives"
                 default: "{{ lookup('env', 'PWD') }}"
-                type: "str"
-            keycloak_quarkus_jgroups_port:
-                description: 'jgroups bind port'
-                default: 7800
-                type: "int"
-            keycloak_quarkus_jgroups_bind_address:
-                description: 'jgroups bind address'
-                default: "{{ ansible_default_ipv4.address }}"
-                type: "str"
-            keycloak_quarkus_jgroups_external_addr:
-                description: 'IP address that other instances in the Keycloak should use to contact this node'
-                default: "{{ keycloak_quarkus_jgroups_bind_address }}"
-                type: "str"
-            keycloak_quarkus_jgroups_external_port:
-                description: 'Port that other instances in the Keycloak cluster should use to contact this node'
-                default: "{{ keycloak_quarkus_jgroups_port }}"
-                type: "int"
-            keycloak_quarkus_jgroups_opts:
-                description: "JVM arguments for jgroups configuration"
-                default: "-Djgroups.bind.address={{ keycloak_quarkus_jgroups_bind_address }} -Djgroups.external_port={{ keycloak_quarkus_jgroups_external_port }} -Djgroups.external_addr={{ keycloak_quarkus_jgroups_external_addr }}"
                 type: "str"
             keycloak_quarkus_cache_managed_infinispan_config:
                 description: "Manage infinispan configuration"


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AMW-518
GitHub Issue: https://github.com/ansible-middleware/keycloak/issues/323

Moving the jgroups variables to appear before keycloak_quarkus_java_heap_opts will work fine.