### PR TITLE
Fix keycloak_context default from /auth to empty string for Quarkus-based Keycloak

### DIFF
--- a/molecule/debian/converge.yml
+++ b/molecule/debian/converge.yml
@@ -13,7 +13,6 @@
     - role: keycloak_quarkus
     - role: keycloak_realm
       keycloak_url: "{{ keycloak_quarkus_hostname }}"
-      keycloak_context: ''
       keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
       keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_users:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -18,7 +18,6 @@
     - role: keycloak_quarkus
     - role: keycloak_realm
       keycloak_url: "{{ keycloak_quarkus_hostname }}"
-      keycloak_context: ''
       keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
       keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_users:

--- a/molecule/quarkus/converge.yml
+++ b/molecule/quarkus/converge.yml
@@ -61,7 +61,6 @@
     - role: keycloak_quarkus
     - role: keycloak_realm
       keycloak_url: http://instance:8080
-      keycloak_context: ''
       keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
       keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_default_roles:

--- a/molecule/quarkus_devmode/converge.yml
+++ b/molecule/quarkus_devmode/converge.yml
@@ -17,7 +17,6 @@
     - role: keycloak_quarkus
     - role: keycloak_realm
       keycloak_url: "{{ keycloak_quarkus_hostname }}"
-      keycloak_context: ''
       keycloak_admin_user: "{{ keycloak_quarkus_bootstrap_admin_user }}"
       keycloak_admin_password: "{{ keycloak_quarkus_bootstrap_admin_password }}"
       keycloak_client_default_roles:

--- a/roles/keycloak_realm/README.md
+++ b/roles/keycloak_realm/README.md
@@ -12,7 +12,7 @@ Role Defaults
 |:---------|:------------|:--------|
 |`keycloak_admin_user`| Administration console user account | `admin` |
 |`keycloak_host`| hostname | `localhost` |
-|`keycloak_context`| Context path for rest calls | `/auth` |
+|`keycloak_context`| Context path for rest calls (set to `/auth` for legacy WildFly-based Keycloak) | `` |
 |`keycloak_http_port`| HTTP port | `8080` |
 |`keycloak_https_port`| TLS HTTP port | `8443` |
 |`keycloak_auth_realm`| Name of the main authentication realm | `master` |

--- a/roles/keycloak_realm/defaults/main.yml
+++ b/roles/keycloak_realm/defaults/main.yml
@@ -9,7 +9,7 @@ keycloak_management_http_port: 9990
 keycloak_admin_user: admin
 keycloak_auth_realm: master
 keycloak_auth_client: admin-cli
-keycloak_context: /auth
+keycloak_context: ''
 
 # administrator console password, this is a required variable
 keycloak_admin_password: ''

--- a/roles/keycloak_realm/meta/argument_specs.yml
+++ b/roles/keycloak_realm/meta/argument_specs.yml
@@ -8,8 +8,8 @@ argument_specs:
                 type: "str"
             keycloak_context:
                 # line 5 of keycloak_realm/defaults/main.yml
-                default: "/auth"
-                description: "Context path for rest calls"
+                default: ""
+                description: "Context path for rest calls (was /auth for legacy WildFly-based Keycloak, empty for Quarkus-based Keycloak/RHBK)"
                 type: "str"
             keycloak_http_port:
                 # line 4 of keycloak_realm/defaults/main.yml


### PR DESCRIPTION
## Summary

- Change the default value of `keycloak_context` from `/auth` to `''` (empty string) in the `keycloak_realm` role
- Update `argument_specs.yml` and `README.md` documentation to reflect the new default
- Remove the now-unnecessary `keycloak_context: ''` overrides from all 4 molecule converge files (`quarkus`, `debian`, `quarkus_devmode`, `default`)

## Problem

The `/auth` context path was used by legacy **WildFly-based Keycloak** (pre-v17). Since the move to Quarkus (Keycloak 17+), the context path is empty by default. The same applies to **Red Hat Build of Keycloak (RHBK)**.

With the current default of `/auth`, all REST API URLs are built incorrectly (e.g. `http://localhost:8080/auth/realms/master/...` instead of `http://localhost:8080/realms/master/...`), forcing every user of Quarkus-based Keycloak/RHBK to explicitly pass:

```yaml
keycloak_context: ""
```

This is a common source of confusion — the molecule tests themselves already had to work around it by setting `keycloak_context: ''` in every converge file.

## Fix

- `roles/keycloak_realm/defaults/main.yml`: `keycloak_context: ''`
- `roles/keycloak_realm/meta/argument_specs.yml`: `default: ""`
- `roles/keycloak_realm/README.md`: updated docs table
- `molecule/*/converge.yml`: removed redundant `keycloak_context: ''` overrides (4 files)

Users still on legacy WildFly-based Keycloak can set `keycloak_context: /auth` explicitly.

## Test plan

- [ ] Existing molecule tests should pass without the explicit `keycloak_context: ''` override
- [ ] Verify Quarkus-based Keycloak realm creation works out of the box without setting context
- [ ] Verify legacy WildFly users can still override with `keycloak_context: /auth`

Made with [Cursor](https://cursor.com)