### PR TITLE
Check that `data/tmp` directory has correct ownership

### DIFF
--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -97,6 +97,15 @@
     mode: '0775'
   become: true
 
+- name: Ensure tmp-directory exists
+  ansible.builtin.file:
+    state: directory
+    path: "{{ keycloak.home }}/data/tmp"
+    owner: "{{ keycloak.service_user }}"
+    group: "{{ keycloak.service_group }}"
+    mode: '0755'
+  become: true
+
 - name: Flush pending handlers
   ansible.builtin.meta: flush_handlers
 


### PR DESCRIPTION
Fixes #329 

In Keycloak 26.6.0 changes to the `data/tmp` directory were introduced. Since then the directory was created with user:group `root:root` instead of `keycloak:keycloak`.
This PR makes sure that the tmp-directory has correct ownership after building Keycloak.