### PR TITLE
Rename keycloak_client_scope to keycloak_clientscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ All Keycloak administration modules from `community.general` are provided in thi
 * `keycloak_client`: manage Keycloak clients (create/update/delete).
 * `keycloak_client_rolemapping`: manage client role mappings for users and groups.
 * `keycloak_client_rolescope`: manage client role scope mappings.
-* `keycloak_client_scope`: manage client scopes and protocol mappers (replaces `community.general.keycloak_clientscope`).
+* `keycloak_clientscope`: manage client scopes and protocol mappers.
+* `keycloak_clientscope_rolemappings`: manage role mappings for client scopes.
 * `keycloak_clientscope_type`: manage default and optional client scope assignments.
 * `keycloak_clientsecret_info`: retrieve client secret information.
 * `keycloak_clientsecret_regenerate`: regenerate a client secret.
@@ -174,7 +175,7 @@ For full configuration details, refer to the [keycloak_realm role README](https:
 
 Module playbooks target an already running Keycloak instance. All modules use the `middleware_automation.keycloak` collection namespace.
 
-* [`playbooks/keycloak_client_scope.yml`](https://github.com/ansible-middleware/keycloak/blob/main/playbooks/keycloak_client_scope.yml) creates a client scope with protocol mappers using the `keycloak_client_scope` module.
+* [`playbooks/keycloak_clientscope.yml`](https://github.com/ansible-middleware/keycloak/blob/main/playbooks/keycloak_clientscope.yml) creates a client scope with protocol mappers using the `keycloak_clientscope` module.
 * [`playbooks/keycloak_authentication_flow.yml`](https://github.com/ansible-middleware/keycloak/blob/main/playbooks/keycloak_authentication_flow.yml) creates a custom authentication flow with execution steps using the `keycloak_authentication_flow` module.
 
 Example task using shared authentication defaults:
@@ -199,7 +200,7 @@ Example task using shared authentication defaults:
         state: present
 ```
 
-When migrating from `community.general`, replace the collection prefix in playbooks (for example `community.general.keycloak_user` becomes `middleware_automation.keycloak.keycloak_user`) and use `keycloak_client_scope` instead of `keycloak_clientscope`.
+When migrating from `community.general`, replace the collection prefix in playbooks (for example `community.general.keycloak_user` becomes `middleware_automation.keycloak.keycloak_user`).
 
 
 ## Support

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -13,7 +13,7 @@ action_groups:
     - keycloak_client
     - keycloak_client_rolemapping
     - keycloak_client_rolescope
-    - keycloak_client_scope
+    - keycloak_clientscope
     - keycloak_clientscope_type
     - keycloak_clientscope_rolemappings
     - keycloak_clientsecret_info
@@ -37,10 +37,3 @@ action_groups:
     - keycloak_user_execute_actions_email
 plugin_routing:
   modules:
-    keycloak_clientscope:
-      redirect: middleware_automation.keycloak.keycloak_client_scope
-      deprecation:
-        removal_version: 5.0.0
-        warning_text: >-
-          The module has been renamed to keycloak_client_scope for Keycloak 17+ (Quarkus).
-          Update playbooks to use middleware_automation.keycloak.keycloak_client_scope.

--- a/molecule/keycloak_modules/verify.yml
+++ b/molecule/keycloak_modules/verify.yml
@@ -36,7 +36,7 @@
       - keycloak_client
       - keycloak_client_rolemapping
       - keycloak_client_rolescope
-      - keycloak_client_scope
+      - keycloak_clientscope
       - keycloak_clientscope_type
       - keycloak_clientscope_rolemappings
       - keycloak_clientsecret_info
@@ -132,8 +132,8 @@
             name: "{{ client_role }}"
             state: present
 
-        - name: keycloak_client_scope — create client scope
-          middleware_automation.keycloak.keycloak_client_scope:
+        - name: keycloak_clientscope — create client scope
+          middleware_automation.keycloak.keycloak_clientscope:
             realm: "{{ target_realm }}"
             name: "{{ scope }}"
             state: present
@@ -644,8 +644,8 @@
             client_id: "{{ client }}"
             state: absent
 
-        - name: keycloak_client_scope — remove client scope
-          middleware_automation.keycloak.keycloak_client_scope:
+        - name: keycloak_clientscope — remove client scope
+          middleware_automation.keycloak.keycloak_clientscope:
             realm: "{{ target_realm }}"
             name: "{{ scope }}"
             state: absent

--- a/playbooks/keycloak_clientscope.yml
+++ b/playbooks/keycloak_clientscope.yml
@@ -8,7 +8,7 @@
     keycloak_realm: TestRealm
   tasks:
     - name: Create client scope with protocol mappers
-      middleware_automation.keycloak.keycloak_client_scope:
+      middleware_automation.keycloak.keycloak_clientscope:
         auth_keycloak_url: "{{ keycloak_url }}"
         auth_realm: master
         auth_username: "{{ keycloak_admin_user }}"

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: keycloak_client_scope
+module: keycloak_clientscope
 
 short_description: Allows administration of Keycloak client scopes via Keycloak API
 
@@ -118,7 +118,7 @@ author:
 
 EXAMPLES = '''
 - name: Create a client scope with protocol mappers
-  middleware_automation.keycloak.keycloak_client_scope:
+  middleware_automation.keycloak.keycloak_clientscope:
     auth_keycloak_url: http://localhost:8080
     auth_realm: master
     auth_username: admin
@@ -142,7 +142,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 - name: Create a client scope using token authentication
-  middleware_automation.keycloak.keycloak_client_scope:
+  middleware_automation.keycloak.keycloak_clientscope:
     auth_keycloak_url: http://localhost:8080
     token: MY_TOKEN
     realm: TestRealm
@@ -151,7 +151,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 - name: Delete a client scope
-  middleware_automation.keycloak.keycloak_client_scope:
+  middleware_automation.keycloak.keycloak_clientscope:
     auth_keycloak_url: http://localhost:8080
     auth_realm: master
     auth_username: admin

--- a/roles/keycloak_realm/README.md
+++ b/roles/keycloak_realm/README.md
@@ -114,7 +114,7 @@ For features not covered by this role, the collection provides dedicated modules
 
 | Module | What It Manages |
 |:-------|:----------------|
-| `keycloak_client_scope` | Client scopes and protocol mappers — see [example playbook](../../playbooks/keycloak_client_scope.yml) |
+| `keycloak_clientscope` | Client scopes and protocol mappers — see [example playbook](../../playbooks/keycloak_clientscope.yml) |
 | `keycloak_authentication_flow` | Authentication flows and execution steps — see [example playbook](../../playbooks/keycloak_authentication_flow.yml) |
 | `keycloak_client` | Clients (also used internally by this role) |
 | `keycloak_role` | Realm and client roles |
@@ -141,11 +141,11 @@ The following is an example playbook that makes use of the role to create a real
             keycloak_clients: [...]
 ```
 
-The following example uses the `keycloak_client_scope` module to create a client scope with protocol mappers:
+The following example uses the `keycloak_clientscope` module to create a client scope with protocol mappers:
 
 ```yaml
 - name: Create client scope
-  middleware_automation.keycloak.keycloak_client_scope:
+  middleware_automation.keycloak.keycloak_clientscope:
     auth_keycloak_url: http://localhost:8080
     auth_realm: master
     auth_username: admin


### PR DESCRIPTION
Restore the original module name from community.general to maintain consistency and avoid breaking changes for users migrating from community.general.keycloak_clientscope.

Changes:
- Renamed plugins/modules/keycloak_client_scope.py to keycloak_clientscope.py
- Renamed playbooks/keycloak_client_scope.yml to keycloak_clientscope.yml
- Updated module documentation and examples
- Removed redirect/deprecation from meta/runtime.yml
- Updated references in README.md, verify.yml, and role documentation

Fixes #346