### PR TITLE
fix(keycloak_quarkus): avoid leaking maven provider password in logs

### DIFF
--- a/roles/keycloak_quarkus/tasks/install.yml
+++ b/roles/keycloak_quarkus/tasks/install.yml
@@ -246,6 +246,7 @@
   become: "{{ keycloak_quarkus_install_require_privilege_escalation | default(true) }}"
   loop: "{{ keycloak_quarkus_providers }}"
   when: item.url is defined and item.url | length > 0
+  no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
   notify: "{{ ['invalidate keycloak theme cache', 'rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or item.restart else [] }}"
 
 # this requires the `lxml` package to be installed; we redirect this step to localhost such that we do need to install it on the remote hosts
@@ -289,6 +290,7 @@
   become: "{{ keycloak_quarkus_install_require_privilege_escalation | default(true) }}"
   loop: "{{ keycloak_quarkus_providers }}"
   when: item.local_path is defined
+  no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
   notify: "{{ ['invalidate keycloak theme cache', 'rebuild keycloak config', 'restart keycloak'] if not item.restart is defined or item.restart else [] }}"
 
 - name: Ensure required folder structure for policies exists

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -123,6 +123,7 @@
     fail_msg: >
       Providers definition incorrect; `id` and one of `spi`, `url`, `local_path`, or `maven` are mandatory. `key` and `value` are mandatory for each property
   loop: "{{ keycloak_quarkus_providers }}"
+  no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
 
 - name: "Validate policies"
   ansible.builtin.assert:


### PR DESCRIPTION
## What

Adds the conditional `no_log` (already used by the maven download/copy tasks) to the three provider-looping tasks that currently print the full `item` — including `maven.password` — in cleartext:

- `roles/keycloak_quarkus/tasks/prereqs.yml` → `Validate providers`
- `roles/keycloak_quarkus/tasks/install.yml` → `Download custom providers via http`
- `roles/keycloak_quarkus/tasks/install.yml` → `Copy local providers`

Because Ansible echoes the loop `item` even for skipped iterations, these tasks leak a private-registry credential (e.g. a GitHub Packages PAT) at default verbosity, on every run.

## Fix

```yaml
no_log: "{{ item.maven.password is defined and item.maven.password | length > 0 | default(false) }}"
```

Only entries carrying a secret (maven `password`) are censored; `url`/`local_path` providers stay fully visible for debugging. This is the exact idiom the `Download custom providers to localhost using maven` and `Copy maven providers` tasks already use.

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
