### PR TITLE
Fix health check URL to include HTTP relative path

### DIFF
--- a/molecule/https_revproxy/converge.yml
+++ b/molecule/https_revproxy/converge.yml
@@ -7,12 +7,11 @@
     keycloak_quarkus_show_deprecation_warnings: false
     keycloak_quarkus_bootstrap_admin_password: "remembertochangeme"
     keycloak_quarkus_bootstrap_admin_user: "remembertochangeme"
-    keycloak_quarkus_hostname: https://proxy
+    keycloak_quarkus_hostname: "http://proxy:{{ keycloak_quarkus_http_port }}"
     keycloak_quarkus_log: file
     keycloak_quarkus_http_enabled: True
     keycloak_quarkus_http_port: 8080
     keycloak_quarkus_proxy_mode: edge
     keycloak_quarkus_http_relative_path: /
-    keycloak_quarkus_health_check_url: http://proxy:8080/realms/master/.well-known/openid-configuration
   roles:
     - role: keycloak_quarkus

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -63,8 +63,8 @@ Role Defaults
 |`keycloak_quarkus_additional_env_vars` | List of additional env variables of { key: str, value: str} to be put in sysconfig file, see https://www.keycloak.org/server/all-config | `[]` |
 |`keycloak_quarkus_frontend_url`| Deprecated, use `keycloak_quarkus_hostname` instead. | |
 |`keycloak_quarkus_admin_url`| Deprecated, use `keycloak_quarkus_hostname_admin` instead. | |
-|`keycloak_quarkus_health_check_url`| Full URL (including scheme, host, path, fragment etc.) used for health check endpoint; keycloak_quarkus_hostname will NOT be prepended; helpful when health checks should happen against http port, but keycloak_quarkus_hostname uses https scheme per default | `` |
-|`keycloak_quarkus_health_check_url_path`| Path to the health check endpoint; keycloak_quarkus_hostname will be prepended automatically; Note that keycloak_quarkus_health_check_url takes precedence over this property | `realms/master/.well-known/openid-configuration` |
+|`keycloak_quarkus_health_check_url`| Full URL (including scheme, host, path, fragment etc.) used for health check endpoint; keycloak_quarkus_hostname will NOT be prepended; helpful when health checks should happen against http port, but keycloak_quarkus_hostname uses https scheme per default | `{{ keycloak_quarkus_hostname ~ keycloak_quarkus_http_relative_path.rstrip('/') ~ '/' ~ keycloak_quarkus_health_check_url_path }}` |
+|`keycloak_quarkus_health_check_url_path`| Path to the health check endpoint; keycloak_quarkus_hostname will be prepended automatically; Note that keycloak_quarkus_health_check_url takes precedence over this property | `realms/{{ keycloak_quarkus_master_realm }}/.well-known/openid-configuration` |
 |`keycloak_quarkus_proxy_headers`| Parse reverse proxy headers (`forwarded` or `xforwarded`) | `""` |
 |`keycloak_quarkus_config_key_store_file`| Path to the configuration key store; only used if `keycloak_quarkus_config_key_store_password` is not empty  | `{{ keycloak.home }}/conf/conf_store.p12` if `keycloak_quarkus_config_key_store_password != ''`, else `''` |
 |`keycloak_quarkus_config_key_store_password`| Password of the configuration keystore; if non-empty, `keycloak_quarkus_db_pass` will be saved to the keystore at `keycloak_quarkus_config_key_store_file` instead of being written to the configuration file in clear text | `""` |
@@ -90,6 +90,7 @@ Role Defaults
 |`keycloak_quarkus_restart_health_check`| Whether to wait for successful health check after restart | `true` |
 |`keycloak_quarkus_restart_health_check_delay`| Seconds to let pass before starting healch checks | `10` |
 |`keycloak_quarkus_restart_health_check_retries`| Number of attempts for successful health check before failing | `25` |
+|`keycloak_quarkus_validate_certs`| Whether to validate SSL certificates when performing health checks | `true` |
 |`keycloak_quarkus_restart_pause`| Seconds to wait between restarts in HA strategy | `15` |
 
 

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -186,6 +186,9 @@ keycloak_quarkus_restart_strategy: restart/serial.yml
 keycloak_quarkus_restart_health_check: true
 keycloak_quarkus_restart_health_check_delay: 10
 keycloak_quarkus_restart_health_check_retries: 25
+keycloak_quarkus_validate_certs: true
+keycloak_quarkus_health_check_url_path: "realms/{{ keycloak_quarkus_master_realm }}/.well-known/openid-configuration"
+keycloak_quarkus_health_check_url: "{{ keycloak_quarkus_hostname ~ keycloak_quarkus_http_relative_path.rstrip('/') ~ '/' ~ keycloak_quarkus_health_check_url_path }}"
 keycloak_quarkus_restart_pause: 15
 
 keycloak_quarkus_force_install: false

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -115,10 +115,11 @@ argument_specs:
                 description: "HTTP port"
                 type: "int"
             keycloak_quarkus_health_check_url:
+                default: "{{ keycloak_quarkus_hostname ~ keycloak_quarkus_http_relative_path.rstrip('/') ~ '/' ~ keycloak_quarkus_health_check_url_path }}"
                 description: "Full URL (including scheme, host, path, fragment etc.) used for health check endpoint; keycloak_quarkus_hostname will NOT be prepended; helpful when health checks should happen against http port, but keycloak_quarkus_hostname uses https scheme per default"
                 type: "str"
             keycloak_quarkus_health_check_url_path:
-                default: "realms/master/.well-known/openid-configuration"
+                default: "realms/{{ keycloak_quarkus_master_realm }}/.well-known/openid-configuration"
                 description: "Path to the health check endpoint; keycloak_quarkus_hostname will be prepended automatically; Note that keycloak_quarkus_health_check_url takes precedence over this property"
                 type: "str"
             keycloak_quarkus_https_key_file_enabled:
@@ -488,6 +489,10 @@ argument_specs:
                 description: "Number of attempts for successful health check before failing"
                 default: 25
                 type: 'int'
+            keycloak_quarkus_validate_certs:
+                description: "Whether to validate SSL certificates when performing health checks"
+                default: true
+                type: "bool"
             keycloak_quarkus_show_deprecation_warnings:
                 default: true
                 description: "Whether or not deprecation warnings should be shown"

--- a/roles/keycloak_quarkus/tasks/restart.yml
+++ b/roles/keycloak_quarkus/tasks/restart.yml
@@ -10,7 +10,7 @@
 - name: "Wait until service becomes active: {{ keycloak.service_name }}"
   ansible.builtin.uri:
     url: "{{ keycloak.health_url }}"
-    validate_certs: "{{ keycloak_quarkus_validate_certs | default(omit) }}"
+    validate_certs: "{{ keycloak_quarkus_validate_certs }}"
   register: keycloak_quarkus_status
   until: keycloak_quarkus_status.status == 200
   retries: "{{ keycloak_quarkus_restart_health_check_retries }}"

--- a/roles/keycloak_quarkus/tasks/start.yml
+++ b/roles/keycloak_quarkus/tasks/start.yml
@@ -10,7 +10,7 @@
 - name: "Wait until service becomes active: {{ keycloak.service_name }}"
   ansible.builtin.uri:
     url: "{{ keycloak.health_url }}"
-    validate_certs: "{{ keycloak_quarkus_validate_certs | default(omit) }}"
+    validate_certs: "{{ keycloak_quarkus_validate_certs }}"
   register: keycloak_quarkus_status
   until: keycloak_quarkus_status.status == 200
   retries: 25

--- a/roles/keycloak_quarkus/vars/main.yml
+++ b/roles/keycloak_quarkus/vars/main.yml
@@ -4,7 +4,7 @@ keycloak: # noqa var-naming this is an internal dict of interpolated values
   config_dir: "{{ keycloak_quarkus_config_dir }}"
   bundle: "{{ keycloak_quarkus_archive }}"
   service_name: "keycloak"
-  health_url: "{{ keycloak_quarkus_health_check_url | default(keycloak_quarkus_hostname ~ '/' ~ (keycloak_quarkus_health_check_url_path | default('realms/master/.well-known/openid-configuration'))) }}"
+  health_url: "{{ keycloak_quarkus_health_check_url }}"
   cli_path: "{{ keycloak_quarkus_home }}/bin/kcadm.sh"
   service_user: "{{ keycloak_quarkus_service_user }}"
   service_group: "{{ keycloak_quarkus_service_group }}"


### PR DESCRIPTION
- Include keycloak_quarkus_http_relative_path in health_url construction
- Use rstrip('/') to handle both default '/' and custom paths like '/auth'
- Add keycloak_quarkus_health_check_validate_certs option for self-signed certs

Fixes #299