### PR TITLE
368 keycloak_realm: Control whether undefined realm attributes are pruned

### DIFF
--- a/molecule/keycloak_modules/verify.yml
+++ b/molecule/keycloak_modules/verify.yml
@@ -195,6 +195,62 @@
             enabled: true
             state: present
 
+        - name: keycloak_realm — modify realm attributes without pruning undefined attributes. Step 1 - Introduce custom realm attributes
+          middleware_automation.keycloak.keycloak_realm:
+            id: "{{ ephemeral_realm }}"
+            realm: "{{ ephemeral_realm }}"
+            enabled: true
+            state: present
+            prune_undefined_realm_attributes: false
+            attributes:
+              custom-realm-attribute-1: 123
+              custom-realm-attribute-2: true
+          register: custom_realm_attributes_result
+
+        - name: Assert realm attribute without pruning undefined data result (Step 1)
+          ansible.builtin.assert:
+            that:
+              - custom_realm_attributes_result is changed
+              - custom_realm_attributes_result.end_state.attributes["custom-realm-attribute-1"] == "123"
+              - custom_realm_attributes_result.end_state.attributes["custom-realm-attribute-2"] == "true"
+
+        - name: keycloak_realm — modify realm attributes without pruning undefined attributes. Step 2 - Verify unchanged custom realm attributes
+          middleware_automation.keycloak.keycloak_realm:
+            id: "{{ ephemeral_realm }}"
+            realm: "{{ ephemeral_realm }}"
+            enabled: true
+            state: present
+            prune_undefined_realm_attributes: false
+            attributes:
+              custom-realm-attribute-2: false
+          register: custom_realm_attributes_result
+
+        - name: Assert realm attribute without pruning undefined data result (Step 2)
+          ansible.builtin.assert:
+            that:
+              - custom_realm_attributes_result is changed
+              - custom_realm_attributes_result.end_state.attributes["custom-realm-attribute-1"] == "123" # should still be 123
+              - custom_realm_attributes_result.end_state.attributes["custom-realm-attribute-2"] == "false"
+
+        - name: keycloak_realm — modify realm attributes with pruning undefined attributes
+          middleware_automation.keycloak.keycloak_realm:
+            id: "{{ ephemeral_realm }}"
+            realm: "{{ ephemeral_realm }}"
+            enabled: true
+            state: present
+            prune_undefined_realm_attributes: true
+            attributes:
+              custom-realm-attribute-3: custom-attribute-3
+          register: custom_realm_attributes_result
+
+        - name: Assert realm attribute with pruning undefined data result
+          ansible.builtin.assert:
+            that:
+              - custom_realm_attributes_result is changed
+              - custom_realm_attributes_result.end_state.attributes["custom-realm-attribute-1"] is not defined
+              - custom_realm_attributes_result.end_state.attributes["custom-realm-attribute-2"] is not defined
+              - custom_realm_attributes_result.end_state.attributes["custom-realm-attribute-3"] == "custom-attribute-3"
+
         - name: keycloak_realm_localization — set locale override
           middleware_automation.keycloak.keycloak_realm_localization:
             parent_id: "{{ target_realm }}"

--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -424,6 +424,13 @@ options:
     aliases:
       - permanentLockout
     type: bool
+  prune_undefined_realm_attributes:
+    description:
+      - If True all realm attributes which are not defined in the attributes dict will be deleted
+    aliases:
+      - pruneUndefinedRealmAttributes
+    type: bool
+    default: true
   quick_login_check_milli_seconds:
     description:
       - The realm quick login check in milliseconds.
@@ -799,6 +806,9 @@ from ansible_collections.middleware_automation.keycloak.plugins.module_utils.ide
     get_token,
     keycloak_argument_spec,
 )
+from ansible_collections.middleware_automation.keycloak.plugins.module_utils.identity.keycloak._keycloak_utils import (
+    merge_settings_without_absent_nulls,
+)
 
 
 def normalise_cr(realmrep):
@@ -920,6 +930,7 @@ def main():
         password_policy=dict(type="str", aliases=["passwordPolicy"], no_log=False),
         organizations_enabled=dict(type="bool", aliases=["organizationsEnabled"]),
         permanent_lockout=dict(type="bool", aliases=["permanentLockout"]),
+        prune_undefined_realm_attributes=dict(type="bool", aliases=["pruneUndefinedRealmAttributes"], default=True),
         quick_login_check_milli_seconds=dict(type="int", aliases=["quickLoginCheckMilliSeconds"]),
         refresh_token_max_reuse=dict(type="int", aliases=["refreshTokenMaxReuse"], no_log=False),
         registration_allowed=dict(type="bool", aliases=["registrationAllowed"]),
@@ -1031,9 +1042,10 @@ def main():
 
     realm = module.params.get("realm")
     state = module.params.get("state")
+    prune_undefined_realm_attributes = module.params.get("prune_undefined_realm_attributes")
 
     # convert module parameters to realm representation parameters (if they belong in there)
-    params_to_ignore = list(keycloak_argument_spec().keys()) + ["state"]
+    params_to_ignore = list(keycloak_argument_spec().keys()) + ["state", "prune_undefined_realm_attributes"]
 
     # Filter and map the parameters names that apply to the role
     realm_params = [x for x in module.params if x not in params_to_ignore and module.params.get(x) is not None]
@@ -1049,6 +1061,9 @@ def main():
 
     for realm_param in realm_params:
         new_param_value = module.params.get(realm_param)
+        if camel(realm_param) == "attributes" and not prune_undefined_realm_attributes:
+            new_param_value = merge_settings_without_absent_nulls(before_realm.get("attributes"), new_param_value)
+
         changeset[camel(realm_param)] = new_param_value
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See https://github.com/ansible-middleware/keycloak/issues/368

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_realm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
