### PR TITLE
369 add integration tests for keycloak_authentication_v2

### DIFF
--- a/molecule/keycloak_modules/keycloak_authentication_v2/actions/fetch_access_token.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/actions/fetch_access_token.yml
@@ -1,0 +1,24 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Get access token
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/realms/{{ auth_realm }}/protocol/openid-connect/token"
+    method: POST
+    status_code: 200
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+    body_format: form-urlencoded
+    body:
+      grant_type: "password"
+      client_id: "admin-cli"
+      username: "{{ auth_username }}"
+      password: "{{ auth_password }}"
+  register: token_response
+  no_log: true
+
+- name: Extract access token
+  ansible.builtin.set_fact:
+    access_token: "{{ token_response.json['access_token'] }}"
+  no_log: true

--- a/molecule/keycloak_modules/keycloak_authentication_v2/actions/flow_v1.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/actions/flow_v1.yml
@@ -1,0 +1,37 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Flow Creation/Update <Integration Test Flow> Version 1
+  middleware_automation.keycloak.keycloak_authentication_v2:
+    realm: "{{ target_realm }}"
+    alias: Integration Test Flow
+    state: present
+    authenticationExecutions:
+      - providerId: idp-review-profile
+        requirement: REQUIRED
+        authenticationConfig:
+          alias: Integration Test Flow - review profile config
+          config:
+            update.profile.on.first.login: "missing"
+      - subFlow: Integration Test Flow - User creation or linking
+        requirement: REQUIRED
+        authenticationExecutions:
+          - providerId: idp-create-user-if-unique
+            requirement: ALTERNATIVE
+            authenticationConfig:
+              alias: Integration Test Flow - create unique user config
+              config:
+                require.password.update.after.registration: "false"
+          - subFlow: Integration Test Flow - Handle Existing Account
+            requirement: ALTERNATIVE
+            authenticationExecutions:
+              - providerId: idp-confirm-link
+                requirement: REQUIRED
+      - providerId: auth-cookie
+        requirement: REQUIRED
+  register: flow_v1_result
+
+- name: Expose flow_v1_result to parent scope
+  ansible.builtin.set_fact:
+    flow_v1_result: "{{ flow_v1_result }}"
+  no_log: true

--- a/molecule/keycloak_modules/keycloak_authentication_v2/actions/flow_v2.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/actions/flow_v2.yml
@@ -1,0 +1,43 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# - adding a new execution inside the sub flow 'Integration Test Flow - User creation or linking' after the execution 'idp-create-user-if-unique'
+# - disable auth-cookie at the end of the flow
+# - change the config require.password.update.after.registration to "true"
+- name: Flow Creation/Update <Integration Test Flow> Version 2
+  middleware_automation.keycloak.keycloak_authentication_v2:
+    realm: "{{ target_realm }}"
+    alias: Integration Test Flow
+    state: present
+    authenticationExecutions:
+      - providerId: idp-review-profile
+        requirement: REQUIRED
+        authenticationConfig:
+          alias: Integration Test Flow - review profile config
+          config:
+            update.profile.on.first.login: "missing"
+      - subFlow: Integration Test Flow - User creation or linking
+        requirement: REQUIRED
+        authenticationExecutions:
+          - providerId: idp-create-user-if-unique
+            requirement: ALTERNATIVE
+            authenticationConfig:
+              alias: Integration Test Flow - create unique user config
+              config:
+                require.password.update.after.registration: "true"
+          - providerId: auth-cookie
+            requirement: REQUIRED
+          - subFlow: Integration Test Flow - Handle Existing Account
+            requirement: ALTERNATIVE
+            authenticationExecutions:
+              - providerId: idp-confirm-link
+                requirement: REQUIRED
+      - providerId: auth-cookie
+        requirement: DISABLED
+  register: flow_v2_result
+
+- name: Expose flow_v2_result to parent scope
+  ansible.builtin.set_fact:
+    flow_v2_result: "{{ flow_v2_result }}"
+  no_log: true

--- a/molecule/keycloak_modules/keycloak_authentication_v2/assertions/assertion_flow_v1.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/assertions/assertion_flow_v1.yml
@@ -1,0 +1,144 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Retrieve access token
+  ansible.builtin.include_tasks:
+    file: ../actions/fetch_access_token.yml
+
+- name: Fetch all authentication flows
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: keycloak_flows_response
+  no_log: true
+
+- name: Extract flow id for alias 'Integration Test Flow'
+  ansible.builtin.set_fact:
+    test_flow_id: >-
+      {{ keycloak_flows_response.json
+          | selectattr('alias', 'equalto', 'Integration Test Flow')
+          | map(attribute='id')
+          | first }}
+  no_log: true
+
+- name: Fetch basic flow data for 'Integration Test Flow'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows/{{ test_flow_id }}"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_top_level_data
+  no_log: true
+
+- name: Assert flow attributes
+  ansible.builtin.assert:
+    that:
+      - test_flow_top_level_data.json.alias == "Integration Test Flow"
+      - test_flow_top_level_data.json.providerId == "basic-flow"
+      - test_flow_top_level_data.json.topLevel == true
+      - test_flow_top_level_data.json.builtIn == false
+
+- name: Fetch flow executions for 'Integration Test Flow'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows/Integration%20Test%20Flow/executions"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_executions
+  no_log: true
+
+- name: Assert flow executions
+  ansible.builtin.assert:
+    that:
+      - test_flow_executions.json | length == 6
+      - test_flow_executions.json[0].providerId == "idp-review-profile"
+      - test_flow_executions.json[0].requirement == "REQUIRED"
+      - test_flow_executions.json[0].index == 0
+      - test_flow_executions.json[0].priority == 0
+      - test_flow_executions.json[0].level == 0
+      - test_flow_executions.json[0].authenticationConfig is not none
+      - test_flow_executions.json[0]['authenticationFlow'] is not defined or test_flow_executions.json[0].authenticationFlow == false
+      - test_flow_executions.json[1].displayName == "Integration Test Flow - User creation or linking"
+      - test_flow_executions.json[1].requirement == "REQUIRED"
+      - test_flow_executions.json[1].index == 1
+      - test_flow_executions.json[1].priority == 1
+      - test_flow_executions.json[1].level == 0
+      - test_flow_executions.json[1]['authenticationConfig'] is not defined
+      - test_flow_executions.json[1].authenticationFlow == true
+      - test_flow_executions.json[2].providerId == "idp-create-user-if-unique"
+      - test_flow_executions.json[2].requirement == "ALTERNATIVE"
+      - test_flow_executions.json[2].index == 0
+      - test_flow_executions.json[2].priority == 0
+      - test_flow_executions.json[2].level == 1
+      - test_flow_executions.json[2].authenticationConfig is not none
+      - test_flow_executions.json[2]['authenticationFlow'] is not defined or test_flow_executions.json[2].authenticationFlow == false
+      - test_flow_executions.json[3].displayName == "Integration Test Flow - Handle Existing Account"
+      - test_flow_executions.json[3].requirement == "ALTERNATIVE"
+      - test_flow_executions.json[3].index == 1
+      - test_flow_executions.json[3].priority == 1
+      - test_flow_executions.json[3].level == 1
+      - test_flow_executions.json[3]['authenticationConfig'] is not defined
+      - test_flow_executions.json[3].authenticationFlow == true
+      - test_flow_executions.json[4].providerId == "idp-confirm-link"
+      - test_flow_executions.json[4].requirement == "REQUIRED"
+      - test_flow_executions.json[4].index == 0
+      - test_flow_executions.json[4].priority == 0
+      - test_flow_executions.json[4].level == 2
+      - test_flow_executions.json[4]['authenticationConfig'] is not defined
+      - test_flow_executions.json[4]['authenticationFlow'] is not defined or test_flow_executions.json[4].authenticationFlow == false
+      - test_flow_executions.json[5].providerId == "auth-cookie"
+      - test_flow_executions.json[5].requirement == "REQUIRED"
+      - test_flow_executions.json[5].index == 2
+      - test_flow_executions.json[5].priority == 2
+      - test_flow_executions.json[5].level == 0
+      - test_flow_executions.json[5]['authenticationConfig'] is not defined
+      - test_flow_executions.json[5]['authenticationFlow'] is not defined or test_flow_executions.json[5].authenticationFlow == false
+
+- name: Fetch flow execution config for 'idp-review-profile'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/config/{{ test_flow_executions.json[0].authenticationConfig }}"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_execution_idp_review_profile_config
+  no_log: true
+
+- name: Assert flow execution config for 'idp-review-profile'
+  ansible.builtin.assert:
+    that:
+      - test_flow_execution_idp_review_profile_config.json.alias == "Integration Test Flow - review profile config"
+      - test_flow_execution_idp_review_profile_config.json.config is not none
+      - test_flow_execution_idp_review_profile_config.json.config['update.profile.on.first.login'] == "missing"
+
+- name: Fetch flow execution config for 'idp-create-user-if-unique'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/config/{{ test_flow_executions.json[2].authenticationConfig }}"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_execution_idp_create_user_if_unique
+  no_log: true
+
+- name: Assert flow execution config for 'idp-create-user-if-unique'
+  ansible.builtin.assert:
+    that:
+      - test_flow_execution_idp_create_user_if_unique.json.alias == "Integration Test Flow - create unique user config"
+      - test_flow_execution_idp_create_user_if_unique.json.config is not none
+      - test_flow_execution_idp_create_user_if_unique.json.config['require.password.update.after.registration'] == "false"

--- a/molecule/keycloak_modules/keycloak_authentication_v2/assertions/assertion_flow_v2.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/assertions/assertion_flow_v2.yml
@@ -1,0 +1,151 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Retrieve access token
+  ansible.builtin.include_tasks:
+    file: ../actions/fetch_access_token.yml
+
+- name: Fetch all authentication flows
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: keycloak_flows_response
+  no_log: true
+
+- name: Extract flow id for alias 'Integration Test Flow'
+  ansible.builtin.set_fact:
+    test_flow_id: >-
+      {{ keycloak_flows_response.json
+          | selectattr('alias', 'equalto', 'Integration Test Flow')
+          | map(attribute='id')
+          | first }}
+  no_log: true
+
+- name: Fetch basic flow data for 'Integration Test Flow'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows/{{ test_flow_id }}"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_top_level_data
+  no_log: true
+
+- name: Assert flow attributes
+  ansible.builtin.assert:
+    that:
+      - test_flow_top_level_data.json.alias == "Integration Test Flow"
+      - test_flow_top_level_data.json.providerId == "basic-flow"
+      - test_flow_top_level_data.json.topLevel == true
+      - test_flow_top_level_data.json.builtIn == false
+
+- name: Fetch flow executions for 'Integration Test Flow'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows/Integration%20Test%20Flow/executions"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_executions
+  no_log: true
+
+- name: Assert flow executions
+  ansible.builtin.assert:
+    that:
+      - test_flow_executions.json | length == 7
+      - test_flow_executions.json[0].providerId == "idp-review-profile"
+      - test_flow_executions.json[0].requirement == "REQUIRED"
+      - test_flow_executions.json[0].index == 0
+      - test_flow_executions.json[0].priority == 0
+      - test_flow_executions.json[0].level == 0
+      - test_flow_executions.json[0].authenticationConfig is not none
+      - test_flow_executions.json[0]['authenticationFlow'] is not defined or test_flow_executions.json[0].authenticationFlow == false
+      - test_flow_executions.json[1].displayName == "Integration Test Flow - User creation or linking"
+      - test_flow_executions.json[1].requirement == "REQUIRED"
+      - test_flow_executions.json[1].index == 1
+      - test_flow_executions.json[1].priority == 1
+      - test_flow_executions.json[1].level == 0
+      - test_flow_executions.json[1]['authenticationConfig'] is not defined
+      - test_flow_executions.json[1].authenticationFlow == true
+      - test_flow_executions.json[2].providerId == "idp-create-user-if-unique"
+      - test_flow_executions.json[2].requirement == "ALTERNATIVE"
+      - test_flow_executions.json[2].index == 0
+      - test_flow_executions.json[2].priority == 0
+      - test_flow_executions.json[2].level == 1
+      - test_flow_executions.json[2].authenticationConfig is not none
+      - test_flow_executions.json[2]['authenticationFlow'] is not defined or test_flow_executions.json[2].authenticationFlow == false
+      - test_flow_executions.json[3].providerId == "auth-cookie"
+      - test_flow_executions.json[3].requirement == "REQUIRED"
+      - test_flow_executions.json[3].index == 1
+      - test_flow_executions.json[3].priority == 1
+      - test_flow_executions.json[3].level == 1
+      - test_flow_executions.json[3]['authenticationConfig'] is not defined
+      - test_flow_executions.json[3]['authenticationFlow'] is not defined or test_flow_executions.json[3].authenticationFlow == false
+      - test_flow_executions.json[4].displayName == "Integration Test Flow - Handle Existing Account"
+      - test_flow_executions.json[4].requirement == "ALTERNATIVE"
+      - test_flow_executions.json[4].index == 2
+      - test_flow_executions.json[4].priority == 2
+      - test_flow_executions.json[4].level == 1
+      - test_flow_executions.json[4]['authenticationConfig'] is not defined
+      - test_flow_executions.json[4].authenticationFlow == true
+      - test_flow_executions.json[5].providerId == "idp-confirm-link"
+      - test_flow_executions.json[5].requirement == "REQUIRED"
+      - test_flow_executions.json[5].index == 0
+      - test_flow_executions.json[5].priority == 0
+      - test_flow_executions.json[5].level == 2
+      - test_flow_executions.json[5]['authenticationConfig'] is not defined
+      - test_flow_executions.json[5]['authenticationFlow'] is not defined or test_flow_executions.json[5].authenticationFlow == false
+      - test_flow_executions.json[6].providerId == "auth-cookie"
+      - test_flow_executions.json[6].requirement == "DISABLED"
+      - test_flow_executions.json[6].index == 2
+      - test_flow_executions.json[6].priority == 2
+      - test_flow_executions.json[6].level == 0
+      - test_flow_executions.json[6]['authenticationConfig'] is not defined
+      - test_flow_executions.json[6]['authenticationFlow'] is not defined or test_flow_executions.json[6].authenticationFlow == false
+
+- name: Fetch flow execution config for 'idp-review-profile'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/config/{{ test_flow_executions.json[0].authenticationConfig }}"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_execution_idp_review_profile_config
+  no_log: true
+
+- name: Assert flow execution config for 'idp-review-profile'
+  ansible.builtin.assert:
+    that:
+      - test_flow_execution_idp_review_profile_config.json.alias == "Integration Test Flow - review profile config"
+      - test_flow_execution_idp_review_profile_config.json.config is not none
+      - test_flow_execution_idp_review_profile_config.json.config['update.profile.on.first.login'] == "missing"
+
+- name: Fetch flow execution config for 'idp-create-user-if-unique'
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/config/{{ test_flow_executions.json[2].authenticationConfig }}"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: test_flow_execution_idp_create_user_if_unique
+  no_log: true
+
+- name: Assert flow execution config for 'idp-create-user-if-unique'
+  ansible.builtin.assert:
+    that:
+      - test_flow_execution_idp_create_user_if_unique.json.alias == "Integration Test Flow - create unique user config"
+      - test_flow_execution_idp_create_user_if_unique.json.config is not none
+      - test_flow_execution_idp_create_user_if_unique.json.config['require.password.update.after.registration'] == "true"

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_client_flow_override_flow_modification.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_client_flow_override_flow_modification.yml
@@ -1,0 +1,61 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Setup Test
+  ansible.builtin.include_tasks:
+    file: test_setup.yml
+
+- name: Create the new flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Create a client with browser override <Integration Test Flow>
+  middleware_automation.keycloak.keycloak_client:
+    realm: "{{ target_realm }}"
+    client_id: "test_client"
+    state: present
+    authentication_flow_binding_overrides:
+      browser_name: "Integration Test Flow"
+
+- name: Modify the flow <Integration Test Flow> although it is bound as client override flow
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v2.yml
+
+- name: Assert the flow modification result
+  ansible.builtin.assert:
+    that:
+      - flow_v2_result is changed
+      - flow_v2_result.diff is defined
+    msg: "Expected changes and a diff but got: changed={{ flow_v2_result.changed }}, diff={{ flow_v2_result.get('diff') }}"
+
+- name: Assert the flow <Integration Test Flow> after the modifications
+  ansible.builtin.include_tasks:
+    file: ../assertions/assertion_flow_v2.yml
+
+- name: Fetch client data
+  middleware_automation.keycloak.keycloak_client:
+    realm: "{{ target_realm }}"
+    client_id: "test_client"
+    state: present
+  register: client_result
+
+- name: Retrieve access token
+  ansible.builtin.include_tasks:
+    file: ../actions/fetch_access_token.yml
+
+- name: Fetch authentication flow (browser override={{ client_result.end_state.authenticationFlowBindingOverrides.browser }})
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows/{{ client_result.end_state.authenticationFlowBindingOverrides.browser }}"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+  register: flow_response
+
+- name: Assert client flow override binding
+  ansible.builtin.assert:
+    that:
+      - flow_response.json is defined
+      - flow_response.json.alias == "Integration Test Flow"

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_flow_creation.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_flow_creation.yml
@@ -1,0 +1,33 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Setup Test
+  ansible.builtin.include_tasks:
+    file: test_setup.yml
+
+- name: Create the new flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Assert the flow creation result
+  ansible.builtin.assert:
+    that:
+      - flow_v1_result is changed
+      - flow_v1_result.diff is defined
+    msg: "Expected changes and a diff but got: changed={{ flow_v1_result.changed }}, diff={{ flow_v1_result.get('diff') }}"
+
+- name: Assert the created flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../assertions/assertion_flow_v1.yml
+
+# Check idempotency, by trying to create the existing flow again
+- name: Trying to create the <Integration Test Flow> again, although nothing changed
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Assert that the task didn't re-create the flow, because the flow didn't change
+  ansible.builtin.assert:
+    that:
+      - flow_v1_result is not changed
+      - flow_v1_result.diff is not defined
+    msg: "Expected no changes and no diff but got: changed={{ flow_v1_result.changed }}, diff={{ flow_v1_result.get('diff') }}"

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_flow_deletion.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_flow_deletion.yml
@@ -1,0 +1,40 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Setup Test
+  ansible.builtin.include_tasks:
+    file: test_setup.yml
+
+- name: Create the new flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Delete the flow <Integration Test Flow>
+  middleware_automation.keycloak.keycloak_authentication_v2:
+    realm: "{{ target_realm }}"
+    alias: Integration Test Flow
+    state: absent
+  register: flow_deletion_result
+
+- name: Assert that the flow deletion result
+  ansible.builtin.assert:
+    that:
+      - flow_deletion_result is changed
+      - flow_deletion_result.diff is defined
+    msg: "Expected changes and a diff but got: changed={{ flow_deletion_result.changed }}, diff={{ flow_deletion_result.get('diff') }}"
+
+- name: Retrieve access token
+  ansible.builtin.include_tasks:
+    file: ../actions/fetch_access_token.yml
+
+- name: Assert that the flow does not exist anymore
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows/Integration%20Test%20Flow/executions"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+    status_code: 404
+  register: flow_response

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_identity_provider_flow_overrides_flow_modification.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_identity_provider_flow_overrides_flow_modification.yml
@@ -1,0 +1,58 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Setup Test
+  ansible.builtin.include_tasks:
+    file: test_setup.yml
+
+- name: Create the new flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Create an identity-provider with first and post login flow override <Integration Test Flow>
+  middleware_automation.keycloak.keycloak_identity_provider:
+    realm: "{{ target_realm }}"
+    alias: oidc-idp-integration-test
+    state: present
+    display_name: OpenID Connect IdP - Integration Test
+    enabled: true
+    provider_id: oidc
+    first_broker_login_flow_alias: Integration Test Flow
+    post_broker_login_flow_alias: Integration Test Flow
+    config:
+      issuer: https://idp.example.com
+      authorizationUrl: https://idp.example.com/auth
+      tokenUrl: https://idp.example.com/token
+      userInfoUrl: https://idp.example.com/userinfo
+      clientAuthMethod: client_secret_post
+      clientId: my-client
+      clientSecret: secret
+      syncMode: FORCE
+
+- name: Modify the flow <Integration Test Flow> although it is bound as identity-provider first and post login flow
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v2.yml
+
+- name: Assert the flow modification result
+  ansible.builtin.assert:
+    that:
+      - flow_v2_result is changed
+      - flow_v2_result.diff is defined
+    msg: "Expected changes and a diff but got: changed={{ flow_v2_result.changed }}, diff={{ flow_v2_result.get('diff') }}"
+
+- name: Assert the flow <Integration Test Flow> after the modifications
+  ansible.builtin.include_tasks:
+    file: ../assertions/assertion_flow_v2.yml
+
+- name: Fetch identity-provider data
+  middleware_automation.keycloak.keycloak_identity_provider:
+    realm: "{{ target_realm }}"
+    alias: oidc-idp-integration-test
+    state: present
+  register: identity_provider_result
+
+- name: Assert identity-provider first and post flow binding
+  ansible.builtin.assert:
+    that:
+      - identity_provider_result.end_state.firstBrokerLoginFlowAlias == "Integration Test Flow"
+      - identity_provider_result.end_state.postBrokerLoginFlowAlias == "Integration Test Flow"

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_invalid_poviderid_flow_creation.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_invalid_poviderid_flow_creation.yml
@@ -1,0 +1,58 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+- name: Setup Test
+  ansible.builtin.include_tasks:
+    file: test_setup.yml
+
+- name: Flow Creation/Update <Integration Test Flow with invalid providerid in execution>
+  middleware_automation.keycloak.keycloak_authentication_v2:
+    realm: "{{ target_realm }}"
+    alias: Integration Test Flow with invalid providerid in execution
+    state: present
+    authenticationExecutions:
+      - providerId: idp-review-profile
+        requirement: REQUIRED
+        authenticationConfig:
+          alias: Integration Test Flow - review profile config
+          config:
+            update.profile.on.first.login: "missing"
+      - subFlow: Integration Test Flow - User creation or linking
+        requirement: REQUIRED
+        authenticationExecutions:
+          - providerId: invalid-providerid
+            requirement: ALTERNATIVE
+          - subFlow: Integration Test Flow - Handle Existing Account
+            requirement: ALTERNATIVE
+            authenticationExecutions:
+              - providerId: another-invalid-providerid
+                requirement: REQUIRED
+      - providerId: auth-cookie
+        requirement: REQUIRED
+  ignore_errors: true
+  register: invalid_providerid_in_flow_result
+
+- name: Verify that invalid providerId causes failure
+  ansible.builtin.assert:
+    that:
+      - invalid_providerid_in_flow_result is failed
+      - invalid_providerid_in_flow_result is not changed
+      - >-
+        invalid_providerid_in_flow_result.msg == "Validation of executions failed: The following execution providerIds are unknown and therefore invalid: 'invalid-providerid', 'another-invalid-providerid'"
+
+- name: Retrieve access token
+  ansible.builtin.include_tasks:
+    file: ../actions/fetch_access_token.yml
+
+- name: Assert that the flow did not get created
+  ansible.builtin.uri:
+    url: "{{ auth_keycloak_url }}/admin/realms/{{ target_realm }}/authentication/flows/Integration%20Test%20Flow%20with%20invalid%20providerid%20in%20execution/executions"
+    method: GET
+    headers:
+      Accept: application/json
+      User-agent: Ansible
+      Authorization: "Bearer {{ access_token }}"
+    return_content: true
+    status_code: 404
+  register: flow_response

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_setup.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_setup.yml
@@ -1,0 +1,27 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Delete identity-provider <oidc-idp-integration-test> if it exists
+  middleware_automation.keycloak.keycloak_identity_provider:
+    realm: "{{ target_realm }}"
+    alias: oidc-idp-integration-test
+    state: absent
+
+- name: Delete client <test_client> if it exists
+  middleware_automation.keycloak.keycloak_client:
+    realm: "{{ target_realm }}"
+    client_id: "test_client"
+    state: absent
+
+- name: Unassign the flow <Integration Test Flow> as default browser flow
+  middleware_automation.keycloak.keycloak_realm:
+    id: "{{ target_realm }}"
+    realm: "{{ target_realm }}"
+    state: present
+    browser_flow: browser
+
+- name: Delete <Integration Test Flow> flow if it exists
+  middleware_automation.keycloak.keycloak_authentication_v2:
+    realm: "{{ target_realm }}"
+    alias: Integration Test Flow
+    state: absent

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_unused_flow_modification.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_unused_flow_modification.yml
@@ -1,0 +1,41 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Setup Test
+  ansible.builtin.include_tasks:
+    file: test_setup.yml
+
+- name: Create the new flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Modify the flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v2.yml
+
+- name: Assert the flow creation modification result
+  ansible.builtin.assert:
+    that:
+      - flow_v2_result is changed
+      - flow_v2_result.diff is defined
+    msg: "Expected changes and a diff but got: changed={{ flow_v2_result.changed }}, diff={{ flow_v2_result.get('diff') }}"
+
+- name: Assert the modified flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../assertions/assertion_flow_v2.yml
+
+# Revert the modifications from the previous step
+- name: Revert the modifications the flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Assert the flow modification result
+  ansible.builtin.assert:
+    that:
+      - flow_v1_result is changed
+      - flow_v1_result.diff is defined
+    msg: "Expected changes and a diff but got: changed={{ flow_v1_result.changed }}, diff={{ flow_v1_result.get('diff') }}"
+
+- name: Assert the flow <Integration Test Flow> after reverting the modifications
+  ansible.builtin.include_tasks:
+    file: ../assertions/assertion_flow_v1.yml

--- a/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_used_default_browser_flow_modification.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/tests/test_used_default_browser_flow_modification.yml
@@ -1,0 +1,44 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Setup Test
+  ansible.builtin.include_tasks:
+    file: test_setup.yml
+
+- name: Create the new flow <Integration Test Flow>
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v1.yml
+
+- name: Assign the flow <Integration Test Flow> as default browser flow
+  middleware_automation.keycloak.keycloak_realm:
+    id: "{{ target_realm }}"
+    realm: "{{ target_realm }}"
+    state: present
+    browser_flow: Integration Test Flow
+
+- name: Modify the flow <Integration Test Flow> although it is bound as realm browser flow
+  ansible.builtin.include_tasks:
+    file: ../actions/flow_v2.yml
+
+- name: Assert the flow modification result
+  ansible.builtin.assert:
+    that:
+      - flow_v2_result is changed
+      - flow_v2_result.diff is defined
+    msg: "Expected changes and a diff but got: changed={{ flow_v2_result.changed }}, diff={{ flow_v2_result.get('diff') }}"
+
+- name: Assert the flow <Integration Test Flow> after the modifications
+  ansible.builtin.include_tasks:
+    file: ../assertions/assertion_flow_v2.yml
+
+- name: Fetch realm data to validate if the browser flow is still set to <Integration Test Flow>
+  middleware_automation.keycloak.keycloak_realm:
+    id: "{{ target_realm }}"
+    realm: "{{ target_realm }}"
+    state: present
+  register: realm_result
+
+- name: Assert realm browser flow binding
+  ansible.builtin.assert:
+    that:
+      - realm_result.end_state.browserFlow == "Integration Test Flow"

--- a/molecule/keycloak_modules/keycloak_authentication_v2/verify.yml
+++ b/molecule/keycloak_modules/keycloak_authentication_v2/verify.yml
@@ -1,0 +1,27 @@
+- name: Executing flow creation tests
+  ansible.builtin.include_tasks:
+    file: tests/test_flow_creation.yml
+
+- name: Executing unused flow modification tests
+  ansible.builtin.include_tasks:
+    file: tests/test_unused_flow_modification.yml
+
+- name: Executing used default browser flow modification tests
+  ansible.builtin.include_tasks:
+    file: tests/test_used_default_browser_flow_modification.yml
+
+- name: Executing client flow override flow modification tests
+  ansible.builtin.include_tasks:
+    file: tests/test_client_flow_override_flow_modification.yml
+
+- name: Executing identity provider first and post flow override flow modification tests
+  ansible.builtin.include_tasks:
+    file: tests/test_identity_provider_flow_overrides_flow_modification.yml
+
+- name: Executing flow deletion tests
+  ansible.builtin.include_tasks:
+    file: tests/test_flow_deletion.yml
+
+- name: Invalid providerIds in execution tests
+  ansible.builtin.include_tasks:
+    file: tests/test_invalid_poviderid_flow_creation.yml

--- a/molecule/keycloak_modules/verify.yml
+++ b/molecule/keycloak_modules/verify.yml
@@ -441,14 +441,8 @@
             state: present
 
         - name: keycloak_authentication_v2 — manage flow with safe-swap semantics
-          middleware_automation.keycloak.keycloak_authentication_v2:
-            realm: "{{ target_realm }}"
-            alias: "{{ flow_v2 }}"
-            description: Molecule module test flow v2
-            authenticationExecutions:
-              - requirement: REQUIRED
-                providerId: auth-cookie
-            state: present
+          ansible.builtin.include_tasks:
+            file: keycloak_authentication_v2/verify.yml
 
         - name: keycloak_authentication_required_actions — ensure VERIFY_EMAIL is enabled
           middleware_automation.keycloak.keycloak_authentication_required_actions:
@@ -841,12 +835,6 @@
           middleware_automation.keycloak.keycloak_identity_provider:
             realm: "{{ target_realm }}"
             alias: "{{ idp }}"
-            state: absent
-
-        - name: keycloak_authentication_v2 — remove flow
-          middleware_automation.keycloak.keycloak_authentication_v2:
-            realm: "{{ target_realm }}"
-            alias: "{{ flow_v2 }}"
             state: absent
 
         - name: keycloak_authentication — remove copied flow


### PR DESCRIPTION
This PR adds integration tests for the `keycloak_authentication_v2` module.

The tests are based on those from the community.general collection: https://github.com/ansible-collections/community.general/tree/main/tests/integration/targets/keycloak_authentication_v2

This PR includes **only** the integration tests for `keycloak_authentication_v2`.

Partially fixes #369 