### PR TITLE
Remove changelogs/fragments/.gitignore to fix changelog sanity test

### DIFF
--- a/changelogs/fragments/.gitignore
+++ b/changelogs/fragments/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Summary

- Removes `changelogs/fragments/.gitignore` which causes the `changelog` sanity test to fail with: `file must not be a dotfile`
- The `.gitignore` was only present to keep the empty directory tracked by git. The directory is recreated by `antsibull-changelog` when fragments are added, so it does not need to exist in the repo.

## Test plan

- [x] `changelog` sanity test should pass (the only file causing the failure is removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)