### PR TITLE
keycloak_group: fix subgroup lookup on Keycloak older than 25

### DIFF
--- a/molecule/keycloak_modules/verify.yml
+++ b/molecule/keycloak_modules/verify.yml
@@ -12,6 +12,7 @@
     client: molecule-client
     scope: molecule-scope
     group: molecule-group
+    subgroup: molecule-subgroup
     user: molecule-user
     flow: molecule-flow
     flow_v2: molecule-flow-v2
@@ -558,6 +559,61 @@
             state: present
             roles:
               - name: "{{ client_role }}"
+
+        - name: keycloak_group — create subgroup below the parent group
+          middleware_automation.keycloak.keycloak_group:
+            realm: "{{ target_realm }}"
+            name: "{{ subgroup }}"
+            parents:
+              - name: "{{ group }}"
+            state: present
+          register: subgroup_result
+
+        - name: Assert subgroup was created below the parent group
+          ansible.builtin.assert:
+            that:
+              - subgroup_result is changed
+              - subgroup_result.end_state.path == '/' ~ group ~ '/' ~ subgroup
+
+        - name: keycloak_group — create enough siblings to exceed the children page size
+          middleware_automation.keycloak.keycloak_group:
+            realm: "{{ target_realm }}"
+            name: "{{ subgroup }}-{{ item }}"
+            parents:
+              - name: "{{ group }}"
+            state: present
+          loop: "{{ range(1, 13) | list }}"
+
+        - name: keycloak_group — look up a subgroup sorting past the children page size
+          middleware_automation.keycloak.keycloak_group:
+            realm: "{{ target_realm }}"
+            name: "{{ subgroup }}-9"
+            parents:
+              - name: "{{ group }}"
+            state: present
+          register: subgroup_paging_result
+
+        - name: Assert subgroup lookup is not limited to the first page of children
+          ansible.builtin.assert:
+            that:
+              - subgroup_paging_result is not changed
+              - subgroup_paging_result.end_state.path == '/' ~ group ~ '/' ~ subgroup ~ '-9'
+
+        - name: keycloak_realm_rolemapping — assign realm role to subgroup via parents
+          middleware_automation.keycloak.keycloak_realm_rolemapping:
+            realm: "{{ target_realm }}"
+            group_name: "{{ subgroup }}"
+            parents:
+              - name: "{{ group }}"
+            state: present
+            roles:
+              - name: "{{ role }}"
+          register: subgroup_rolemapping_result
+
+        - name: Assert realm role was mapped to the subgroup
+          ansible.builtin.assert:
+            that:
+              - subgroup_rolemapping_result is changed
 
         - name: keycloak_client_rolescope — restrict realm role on client
           middleware_automation.keycloak.keycloak_client_rolescope:

--- a/molecule/sso_test/verify.yml
+++ b/molecule/sso_test/verify.yml
@@ -6,6 +6,8 @@
     keycloak_admin_user: "admin"
     keycloak_uri: "http://localhost:8080"
     keycloak_context: "/auth"
+    parent_group: molecule-parent-group
+    child_group: molecule-child-group
   tasks:
     - name: Populate service facts
       ansible.builtin.service_facts:
@@ -24,3 +26,53 @@
       until: keycloak_auth_response.status == 200
       retries: 2
       delay: 2
+
+    # This Keycloak is older than 23, so its group children endpoint accepts no
+    # GET request and the subgroup lookup has to fall back to the subgroups
+    # inlined in the parent group representation.
+    - name: Verify subgroup handling on a pre-23 Keycloak
+      module_defaults:
+        group/middleware_automation.keycloak.keycloak:
+          auth_keycloak_url: "{{ keycloak_uri }}{{ keycloak_context }}"
+          auth_realm: master
+          auth_username: "{{ keycloak_admin_user }}"
+          auth_password: "{{ keycloak_admin_password }}"
+          validate_certs: false
+          realm: master
+      block:
+        - name: keycloak_group — create parent group
+          middleware_automation.keycloak.keycloak_group:
+            name: "{{ parent_group }}"
+            state: present
+
+        - name: keycloak_group — create subgroup below the parent group
+          middleware_automation.keycloak.keycloak_group:
+            name: "{{ child_group }}"
+            parents:
+              - name: "{{ parent_group }}"
+            state: present
+          register: subgroup_result
+
+        - name: Assert subgroup was created below the parent group
+          ansible.builtin.assert:
+            that:
+              - subgroup_result is changed
+              - subgroup_result.end_state.path == '/' ~ parent_group ~ '/' ~ child_group
+
+        - name: keycloak_group — look the subgroup up through parents again
+          middleware_automation.keycloak.keycloak_group:
+            name: "{{ child_group }}"
+            parents:
+              - name: "{{ parent_group }}"
+            state: present
+          register: subgroup_lookup_result
+
+        - name: Assert the existing subgroup was found instead of re-created
+          ansible.builtin.assert:
+            that:
+              - subgroup_lookup_result is not changed
+      always:
+        - name: keycloak_group — remove parent group and its subtree
+          middleware_automation.keycloak.keycloak_group:
+            name: "{{ parent_group }}"
+            state: absent

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1731,7 +1731,15 @@ class KeycloakAPI:
         except Exception as e:
             self.module.fail_json(msg=f"Could not fetch group {gid} in realm {realm}: {e}")
 
-    def get_subgroups(self, parent, realm: str = "master"):
+    def get_subgroups(self, parent, realm: str = "master", search=None):
+        """Fetch the direct subgroups of a group.
+
+        :param parent: GroupRepresentation of the parent group
+        :param realm: Realm in which the group resides; default "master"
+        :param search: Optional group name, letting the server narrow the result
+            down. This is a hint only: servers which do not support searching
+            return all subgroups, so callers must still match names themselves.
+        """
         if "subGroupCount" in parent:
             # Since version 23, when GETting a group Keycloak does not
             # return subGroups but only a subGroupCount.
@@ -1740,9 +1748,17 @@ class KeycloakAPI:
                 group_children = []
             else:
                 group_children_url = f"{URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent['id'])}?max={parent['subGroupCount']}"
+                if search is not None:
+                    # search/exact are only honoured from version 25 on, 23 and 24
+                    # silently ignore them, which is why max is always sent as the
+                    # full child count.
+                    group_children_url += f"&search={quote(search, safe='')}&exact=true"
                 group_children = self._request_and_deserialize(group_children_url, method="GET")
             subgroups = group_children
         else:
+            # Before version 23 the children endpoint has no GET method at all
+            # (it answers 405 Method Not Allowed), the subgroups are inlined in
+            # the parent representation instead.
             subgroups = parent["subGroups"]
         return subgroups
 
@@ -1750,7 +1766,8 @@ class KeycloakAPI:
         """Fetch a keycloak group within a realm based on its name.
 
         Uses the Keycloak search API with exact matching for efficient lookup
-        instead of fetching all groups.
+        instead of fetching all groups. Servers which do not support searching
+        are handled transparently, see the comments below.
 
         If the group does not exist, None is returned.
         :param name: Name of the group to fetch.
@@ -1764,18 +1781,18 @@ class KeycloakAPI:
                 if not parent:
                     return None
 
-                # For subgroups: use children endpoint with search parameter
-                search_url = "{url}?search={name}&exact=true".format(
-                    url=URL_GROUP_CHILDREN.format(url=self.baseurl, realm=realm, groupid=parent["id"]),
-                    name=quote(name, safe=""),
-                )
+                # For subgroups: search the parent's children where the server
+                # supports it. get_subgroups knows which servers those are, the
+                # exact name check below covers the ones which do not.
+                groups = self.get_subgroups(parent, realm, search=name)
             else:
-                # For top-level groups: use groups endpoint with search parameter
+                # For top-level groups: use groups endpoint with search parameter.
+                # exact was only added in version 20; older servers ignore it and return
+                # substring matches, which the exact name check below sorts out.
                 search_url = "{url}?search={name}&exact=true".format(
                     url=URL_GROUPS.format(url=self.baseurl, realm=realm), name=quote(name, safe="")
                 )
-
-            groups = self._request_and_deserialize(search_url, method="GET")
+                groups = self._request_and_deserialize(search_url, method="GET")
 
             # exact=true should return only exact matches, but verify the name
             for group in groups:


### PR DESCRIPTION
##### SUMMARY

`KeycloakAPI.get_group_by_name()` resolves subgroups through
`GET /admin/realms/{realm}/groups/{id}/children?search=<name>&exact=true`. That request only
works on Keycloak 25 and newer, so every module that accepts `parents` is broken on older
servers — including Red Hat Single Sign-On 7.x and Red Hat build of Keycloak 22 and 24.

| Keycloak | `GET /groups/{id}/children` | `search` / `exact` on it | Result before this PR |
| --- | --- | --- | --- |
| ≤ 22 (RH-SSO 7.x, RHBK 22) | does not exist | – | module fails with `HTTP Error 405: Method Not Allowed` |
| 23, 24 (RHBK 24) | exists | ignored, `max` defaults to 10 | only the first 10 children are returned, so a subgroup that does not sort into the first ten is reported as absent |
| ≥ 25 (RHBK 26.x) | exists | honoured | works |

I stumbled upon this issue on RH-SSO 7.6.12 (Keycloak 18.0.19):

```
fatal: [localhost]: FAILED! => changed=false
  msg: 'Could not fetch group child in realm master: HTTP Error 405: Method Not Allowed'
```

On Keycloak 23 and 24 there is no error, just a wrong answer: `keycloak_group` decides the
subgroup does not exist and then fails on the duplicate `POST /children` with
`409 Sibling group named '<name>' already exists.`, or with `state: absent` reports
"Group does not exist; doing nothing."

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`plugins/module_utils/identity/keycloak/keycloak.py`, affecting `keycloak_group`,
`keycloak_client_rolemapping` and `keycloak_realm_rolemapping` — every module with a `parents`
option, since they all resolve the group through `get_group_by_name()`.

##### ROOT CAUSE

`GroupResource.java` in Keycloak 18.0.2 and 22.0.5 declares `@POST @Path("children")` but no
`@GET`, so the path exists for POST only and we get 405 response:

* https://github.com/keycloak/keycloak/blob/18.0.2/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
* https://github.com/keycloak/keycloak/blob/22.0.5/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java

`@GET @Path("children")` was added in 23.0.0, but as
`getSubGroups(first, max, briefRepresentation)` — no `search`, no `exact`, and
`@DefaultValue("10")` on `max`:

* https://github.com/keycloak/keycloak/blob/23.0.0/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java#L154-L168
* https://github.com/keycloak/keycloak/blob/24.0.5/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java

`search` and `exact` only arrived on that endpoint in 25.0.0:

* https://github.com/keycloak/keycloak/blob/25.0.0/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java#L168-L173

`get_group_by_name()` has two branches and only the `parents` one is broken. The other branch —
taken when no `parents` is given, to resolve a group at the top level of the realm — is fine on
every version and is left alone. The difference is that there `exact` is an unknown *parameter*
on an endpoint that has always existed, rather than a missing endpoint: Keycloak 18's
`GroupsResource.getGroups()` accepts only `search`, `first`, `max` and `briefRepresentation`
(`exact` arrived in 20.0.0), Keycloak ignores the unknown parameter, the
substring `search` still returns the candidates, and the `if group["name"] ==
name` loop does the exact filtering client-side.

##### ORIGIN

The subgroup search came in with community.general
[PR #11503](https://github.com/ansible-collections/community.general/pull/11503) ("keycloak
module utils: group search optimization") and was inherited by this collection in 3.0.7, when
the Keycloak modules were imported from community.general (#341).

That PR fixes a real problem — with thousands of AD-federated groups, listing all groups took
minutes — and assumed that "older Keycloak versions [...] will simply ignore the unknown query
parameter". That holds for `GET /groups`, where only the parameter is new, but not for
`GET /groups/{id}/children`, where the whole method is new, and not for 23/24, where the ignored
parameter turns a targeted lookup into "the first ten children".

Affected releases: `middleware_automation.keycloak` 3.0.7 – 3.0.12, and community.general
12.4.0 – 12.6.4 and 13.0.0 – 13.3.0 (the same code, at 
`plugins/module_utils/identity/keycloak/keycloak.py` in 12.x and 
`plugins/module_utils/_keycloak.py` in 13.x). Not affected: community.general ≤ 12.3.x and
`stable-11`, which call `get_subgroups(parent, realm)` and filter by name.

##### WHAT CHANGED

`get_subgroups()` already knew about the version difference: if the parent representation
carries `subGroupCount` the server is 23 or newer and the children are fetched separately,
otherwise they are read from the parent's inlined `subGroups`. The `parents` branch of
`get_group_by_name()` bypassed that helper and went straight to the children endpoint, which is
the whole bug. This PR makes it use the helper, and gives the helper an optional `search`
argument so the search optimization is not lost:

* `get_group_by_name()` now calls `self.get_subgroups(parent, realm, search=name)` and builds no
  URL of its own, so the capability detection lives in exactly one place.
* `get_subgroups()` appends `&search=<name>&exact=true` to the children request when `search` is
  given, on top of the `max=<subGroupCount>` it already sent. On 25+ that narrows the response to
  a single row; on 23/24 both parameters are ignored but `max` guarantees the complete child
  list, so the existing exact-name check in `get_group_by_name()` still finds the subgroup. On
  older servers `search` is irrelevant, because the subgroups come from the parent representation.
* `search` is documented as a hint — it can be ignored, so callers must still match names
  themselves, which `get_group_by_name()` does and always did.

The number of HTTP requests per lookup is unchanged on every version. A parent with no children
now costs one request fewer, because `get_subgroups()` short-circuits on `subGroupCount == 0`.

##### HOW TESTED

* `molecule/sso_test` provisions the legacy `keycloak` role, which defaults to Keycloak 18.0.2 —
  a server whose children endpoint has no GET method. Its `verify.yml` now contains tasks that
  use the `parents` option of `keycloak_group`: they create a subgroup below a parent group and
  assert the resulting path, then request the same subgroup again and assert that the module
  reports no change, which can only happen if the lookup found the existing subgroup. A cleanup
  task removes the parent group and its subtree afterwards. This is a direct regression test for
  the fix, on a scenario that is already in the CI matrix.
* `molecule/keycloak_modules` (Keycloak 26.6.2) exercised no subgroups at all. Its `verify.yml`
  now creates a subgroup, then twelve more siblings, and re-requests the sibling that sorts past
  the tenth child while asserting no change, which catches a missing or wrong `max` on the fast
  path. It also assigns a realm role to a subgroup through the `parents` option of
  `keycloak_realm_rolemapping`.
* Manually verified against RH-SSO 7.6.12.