### PR TITLE
AMW-626 keycloak_user_rolemapping raises 403 error code while listing asignable Roles if invoker lacks view-realm Role

### DIFF
--- a/molecule/keycloak_modules/verify.yml
+++ b/molecule/keycloak_modules/verify.yml
@@ -159,6 +159,35 @@
             enabled: true
             state: present
 
+        - name: keycloak_role — create realm role for restricted admin test
+          middleware_automation.keycloak.keycloak_role:
+            realm: "{{ target_realm }}"
+            name: "{{ role }}-restricted"
+            state: present
+
+        - name: keycloak_user — create restricted admin in master (manage-users only, no view-realm)
+          middleware_automation.keycloak.keycloak_user:
+            realm: master
+            username: molecule-restricted-admin
+            first_name: Restricted
+            last_name: Admin
+            enabled: true
+            credentials:
+              - type: password
+                value: restricted-admin-password
+                temporary: false
+            state: present
+
+        - name: keycloak_user_rolemapping — grant manage-users for TestRealm to restricted admin
+          middleware_automation.keycloak.keycloak_user_rolemapping:
+            realm: master
+            target_username: molecule-restricted-admin
+            client_id: "{{ target_realm }}-realm"
+            state: present
+            roles:
+              - name: manage-users
+              - name: view-users
+
         - name: keycloak_authentication_flow — create browser-style flow
           middleware_automation.keycloak.keycloak_authentication_flow:
             realm: "{{ target_realm }}"
@@ -543,6 +572,44 @@
             roles:
               - name: "{{ role }}"
 
+        - name: keycloak_user_rolemapping — assign realm role using restricted admin (no view-realm)
+          middleware_automation.keycloak.keycloak_user_rolemapping:
+            auth_keycloak_url: "{{ auth_keycloak_url }}"
+            auth_realm: master
+            auth_username: molecule-restricted-admin
+            auth_password: restricted-admin-password
+            validate_certs: false
+            realm: "{{ target_realm }}"
+            target_username: "{{ user }}"
+            state: present
+            roles:
+              - name: "{{ role }}-restricted"
+          register: restricted_admin_rolemapping_result
+
+        - name: Assert restricted admin can assign realm role without view-realm
+          ansible.builtin.assert:
+            that:
+              - restricted_admin_rolemapping_result is changed
+
+        - name: keycloak_user_rolemapping — idempotency check with restricted admin
+          middleware_automation.keycloak.keycloak_user_rolemapping:
+            auth_keycloak_url: "{{ auth_keycloak_url }}"
+            auth_realm: master
+            auth_username: molecule-restricted-admin
+            auth_password: restricted-admin-password
+            validate_certs: false
+            realm: "{{ target_realm }}"
+            target_username: "{{ user }}"
+            state: present
+            roles:
+              - name: "{{ role }}-restricted"
+          register: restricted_admin_rolemapping_idempotent_result
+
+        - name: Assert restricted admin rolemapping is idempotent
+          ansible.builtin.assert:
+            that:
+              - restricted_admin_rolemapping_idempotent_result is not changed
+
         - name: keycloak_realm_rolemapping — assign realm role to group
           middleware_automation.keycloak.keycloak_realm_rolemapping:
             realm: "{{ target_realm }}"
@@ -886,6 +953,26 @@
             state: absent
             roles:
               - name: "{{ role }}"
+
+        - name: keycloak_user_rolemapping — remove restricted admin role mapping from user
+          middleware_automation.keycloak.keycloak_user_rolemapping:
+            realm: "{{ target_realm }}"
+            target_username: "{{ user }}"
+            state: absent
+            roles:
+              - name: "{{ role }}-restricted"
+
+        - name: keycloak_user — remove restricted admin user from master
+          middleware_automation.keycloak.keycloak_user:
+            realm: master
+            username: molecule-restricted-admin
+            state: absent
+
+        - name: keycloak_role — remove restricted admin test role
+          middleware_automation.keycloak.keycloak_role:
+            realm: "{{ target_realm }}"
+            name: "{{ role }}-restricted"
+            state: absent
 
         - name: keycloak_identity_provider — remove OIDC provider
           middleware_automation.keycloak.keycloak_identity_provider:

--- a/plugins/modules/keycloak_user_rolemapping.py
+++ b/plugins/modules/keycloak_user_rolemapping.py
@@ -337,44 +337,47 @@ def main():
             module.fail_json(msg=f"Could not fetch client {client_id}:")
     if roles is None:
         module.exit_json(msg="Nothing to do (no roles specified).")
-    else:
-        for role in roles:
-            if role.get("name") is None and role.get("id") is None:
-                module.fail_json(msg="Either the `name` or `id` has to be specified on each role.")
-            # Fetch missing role_id
-            if role.get("id") is None:
-                if cid is None:
-                    role_id = kc.get_realm_role(name=role.get("name"), realm=realm)["id"]
-                else:
-                    role_id = kc.get_client_role_id_by_name(cid=cid, name=role.get("name"), realm=realm)
-                if role_id is not None:
-                    role["id"] = role_id
-                else:
-                    module.fail_json(
-                        msg=f"Could not fetch role {role.get('name')} for client_id {client_id} or realm {realm}"
-                    )
-            # Fetch missing role_name
-            else:
-                if cid is None:
-                    role_rep = kc.get_realm_user_rolemapping_by_id(uid=uid, rid=role.get("id"), realm=realm)
-                    if role_rep is not None:
-                        role["name"] = role_rep["name"]
-                else:
-                    role_rep = kc.get_client_user_rolemapping_by_id(uid=uid, cid=cid, rid=role.get("id"), realm=realm)
-                    if role_rep is not None:
-                        role["name"] = role_rep["name"]
-                if role.get("name") is None:
-                    module.fail_json(
-                        msg=f"Could not fetch role {role.get('id')} for client_id {client_id} or realm {realm}"
-                    )
 
-    # Get effective role mappings
+    # Get available and assigned role mappings using user-scoped endpoints
+    # (these do not require the view-realm permission)
     if cid is None:
         available_roles_before = kc.get_realm_user_available_rolemappings(uid=uid, realm=realm)
         assigned_roles_before = kc.get_realm_user_composite_rolemappings(uid=uid, realm=realm)
     else:
         available_roles_before = kc.get_client_user_available_rolemappings(uid=uid, cid=cid, realm=realm)
         assigned_roles_before = kc.get_client_user_composite_rolemappings(uid=uid, cid=cid, realm=realm)
+
+    all_known_roles = available_roles_before + assigned_roles_before
+
+    for role in roles:
+        if role.get("name") is None and role.get("id") is None:
+            module.fail_json(msg="Either the `name` or `id` has to be specified on each role.")
+        # Fetch missing role_id
+        if role.get("id") is None:
+            role_id = None
+            for r in all_known_roles:
+                if r["name"] == role.get("name"):
+                    role_id = r["id"]
+                    break
+            if role_id is not None:
+                role["id"] = role_id
+            else:
+                module.fail_json(
+                    msg=f"Could not fetch role {role.get('name')} for client_id {client_id} or realm {realm}"
+                )
+        # Fetch missing role_name
+        elif role.get("name") is None:
+            role_name = None
+            for r in all_known_roles:
+                if r["id"] == role.get("id"):
+                    role_name = r["name"]
+                    break
+            if role_name is not None:
+                role["name"] = role_name
+            else:
+                module.fail_json(
+                    msg=f"Could not fetch role {role.get('id')} for client_id {client_id} or realm {realm}"
+                )
 
     result["existing"] = assigned_roles_before
     result["proposed"] = roles


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AMW-626
GitHub Issue: https://github.com/ansible-middleware/keycloak/issues/410