### PR TITLE
Replace deprecated top-level fact variables with ansible_fact

### DIFF
--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -256,8 +256,8 @@
         {
           "name": item,
           "address": 'jgroups-' + item,
-          "inventory_host": hostvars[item].ansible_default_ipv4.address | default(item) + '[' + (keycloak_jgroups_port | string) + ']',
-          "value": hostvars[item].ansible_default_ipv4.address | default(item)
+          "inventory_host": hostvars[item].ansible_facts['default_ipv4']['address'] | default(item) + '[' + (keycloak_jgroups_port | string) + ']',
+          "value": hostvars[item].ansible_facts['default_ipv4']['address'] | default(item)
         }
       ] }}
   loop: "{{ ansible_play_batch }}"

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Distro specific tasks
   ansible.builtin.include_tasks:
-    file: "{{ ansible_os_family | lower }}.yml"
+    file: "{{ ansible_facts['os_family'] | lower }}.yml"
     apply:
       tags:
         - unbound

--- a/roles/keycloak/tasks/prereqs.yml
+++ b/roles/keycloak/tasks/prereqs.yml
@@ -42,13 +42,13 @@
 - name: Validate OS family
   ansible.builtin.assert:
     that:
-      - ansible_os_family in ["RedHat", "Debian"]
+      - ansible_facts['os_family'] in ["RedHat", "Debian"]
     quiet: true
-    fail_msg: "Can only install on RedHat or Debian OS families; found {{ ansible_os_family }}"
-    success_msg: "Installing on {{ ansible_os_family }}"
+    fail_msg: "Can only install on RedHat or Debian OS families; found {{ ansible_facts['os_family'] }}"
+    success_msg: "Installing on {{ ansible_facts['os_family'] }}"
 
 - name: Load OS specific variables
-  ansible.builtin.include_vars: "vars/{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "vars/{{ ansible_facts['os_family'] | lower }}.yml"
   tags:
     - always
 

--- a/roles/keycloak/templates/15.0.8/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/15.0.8/standalone-infinispan.xml.j2
@@ -727,8 +727,8 @@
             <inet-address value="{{ keycloak_management_port_bind_address }}"/>
         </interface>
         <interface name="jgroups">
-{% if ansible_default_ipv4 is defined %}
-            <subnet-match value="{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"/>
+{% if ansible_facts['default_ipv4'] is defined %}
+            <subnet-match value="{{ (ansible_facts['default_ipv4']['network'] + '/' + ansible_facts['default_ipv4']['netmask']) | ansible.utils.ipaddr('net') }}"/>
 {% else %}
             <any-address />
 {% endif %}

--- a/roles/keycloak/templates/9.0.2/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/9.0.2/standalone-infinispan.xml.j2
@@ -724,8 +724,8 @@
             <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
         </interface>
         <interface name="jgroups">
-{% if ansible_default_ipv4 is defined %}
-            <subnet-match value="{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"/>
+{% if ansible_facts['default_ipv4'] is defined %}
+            <subnet-match value="{{ (ansible_facts['default_ipv4']['network'] + '/' + ansible_facts['default_ipv4']['netmask']) | ansible.utils.ipaddr('net') }}"/>
 {% else %}
             <any-address />
 {% endif %}

--- a/roles/keycloak/templates/standalone-ha.xml.j2
+++ b/roles/keycloak/templates/standalone-ha.xml.j2
@@ -664,8 +664,8 @@
         <interface name="jgroups">
 {% if keycloak_jgroups_subnet is defined and keycloak_jgroups_subnet is not none and keycloak_jgroups_subnet | string | length > 0 %}
             <subnet-match value="{{ keycloak_jgroups_subnet | string }}"/>
-{% elif ansible_default_ipv4 is defined and (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') | length > 0 %}
-            <subnet-match value="{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"/>
+{% elif ansible_facts['default_ipv4'] is defined and (ansible_facts['default_ipv4']['network'] + '/' + ansible_facts['default_ipv4']['netmask']) | ansible.utils.ipaddr('net') | length > 0 %}
+            <subnet-match value="{{ (ansible_facts['default_ipv4']['network'] + '/' + ansible_facts['default_ipv4']['netmask']) | ansible.utils.ipaddr('net') }}"/>
 {% else %}
             <any-address />
 {% endif %}

--- a/roles/keycloak/templates/standalone-infinispan.xml.j2
+++ b/roles/keycloak/templates/standalone-infinispan.xml.j2
@@ -702,8 +702,8 @@
         <interface name="jgroups">
 {% if keycloak_jgroups_subnet is defined and keycloak_jgroups_subnet is not none and keycloak_jgroups_subnet | string | length > 0 %}
             <subnet-match value="{{ keycloak_jgroups_subnet | string }}"/>
-{% elif ansible_default_ipv4 is defined and (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') | length > 0 %}
-            <subnet-match value="{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ansible.utils.ipaddr('net') }}"/>
+{% elif ansible_facts['default_ipv4'] is defined and (ansible_facts['default_ipv4']['network'] + '/' + ansible_facts['default_ipv4']['netmask']) | ansible.utils.ipaddr('net') | length > 0 %}
+            <subnet-match value="{{ (ansible_facts['default_ipv4']['network'] + '/' + ansible_facts['default_ipv4']['netmask']) | ansible.utils.ipaddr('net') }}"/>
 {% else %}
             <any-address />
 {% endif %}

--- a/roles/keycloak_quarkus/README.md
+++ b/roles/keycloak_quarkus/README.md
@@ -79,7 +79,7 @@ Role Defaults
 |`keycloak_quarkus_ha_enabled`| Enable auto configuration for database backend, clustering and remote caches on infinispan | `False` |
 |`keycloak_quarkus_ha_discovery`| Discovery protocol for HA cluster members | `JDBCPING` |
 |`keycloak_quarkus_db_enabled`| Enable auto configuration for database backend | `True` if `keycloak_quarkus_ha_enabled` is True, else `False` |
-|`keycloak_quarkus_jgroups_ip`| Host jgroups IP.  If changing this variable you must make sure it is always set for all hosts in your cluster. | `{{ ansible_default_ipv4.address }}` |
+|`keycloak_quarkus_jgroups_ip`| Host jgroups IP.  If changing this variable you must make sure it is always set for all hosts in your cluster. | `{{ ansible_facts['default_ipv4']['address'] }}` |
 |`keycloak_quarkus_jgroups_port`| jgroups cluster tcp port | `7800` |
 |`keycloak_quarkus_systemd_wait_for_port` | Whether systemd unit should wait for keycloak port before returning | `{{ keycloak_quarkus_ha_enabled }}` |
 |`keycloak_quarkus_systemd_wait_for_port_number`| Which port the systemd unit should wait for | `{{ keycloak_quarkus_https_port }}` |

--- a/roles/keycloak_quarkus/defaults/main.yml
+++ b/roles/keycloak_quarkus/defaults/main.yml
@@ -43,7 +43,7 @@ keycloak_quarkus_http_port: 8080
 keycloak_quarkus_https_port: 8443
 keycloak_quarkus_http_management_port: 9000
 keycloak_quarkus_jgroups_port: 7800
-keycloak_quarkus_jgroups_bind_address: "{{ ansible_default_ipv4.address }}"
+keycloak_quarkus_jgroups_bind_address: "{{ ansible_facts['default_ipv4']['address'] }}"
 keycloak_quarkus_jgroups_external_addr: "{{ keycloak_quarkus_jgroups_bind_address }}"
 keycloak_quarkus_jgroups_external_port: "{{ keycloak_quarkus_jgroups_port }}"
 keycloak_quarkus_java_heap_opts: "-Xms1024m -Xmx2048m"

--- a/roles/keycloak_quarkus/meta/argument_specs.yml
+++ b/roles/keycloak_quarkus/meta/argument_specs.yml
@@ -206,7 +206,7 @@ argument_specs:
                 type: "int"
             keycloak_quarkus_jgroups_bind_address:
                 description: 'jgroups bind address'
-                default: "{{ ansible_default_ipv4.address }}"
+                default: "{{ ansible_facts['default_ipv4']['address'] }}"
                 type: "str"
             keycloak_quarkus_jgroups_external_addr:
                 description: 'IP address that other instances in the Keycloak should use to contact this node'

--- a/roles/keycloak_quarkus/tasks/main.yml
+++ b/roles/keycloak_quarkus/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Distro specific tasks
   ansible.builtin.include_tasks:
-    file: "{{ ansible_os_family | lower }}.yml"
+    file: "{{ ansible_facts['os_family'] | lower }}.yml"
     apply:
       tags:
         - unbound

--- a/roles/keycloak_quarkus/tasks/prereqs.yml
+++ b/roles/keycloak_quarkus/tasks/prereqs.yml
@@ -39,13 +39,13 @@
 - name: Validate OS family
   ansible.builtin.assert:
     that:
-      - ansible_os_family in ["RedHat", "Debian"]
+      - ansible_facts['os_family'] in ["RedHat", "Debian"]
     quiet: true
-    fail_msg: "Can only install on RedHat or Debian OS families; found {{ ansible_os_family }}"
-    success_msg: "Installing on {{ ansible_os_family }}"
+    fail_msg: "Can only install on RedHat or Debian OS families; found {{ ansible_facts['os_family'] }}"
+    success_msg: "Installing on {{ ansible_facts['os_family'] }}"
 
 - name: Load OS specific variables
-  ansible.builtin.include_vars: "vars/{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "vars/{{ ansible_facts['os_family'] | lower }}.yml"
   tags:
     - always
 


### PR DESCRIPTION
Fix deprecation warnings:

[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.

[AMW-628](https://redhat.atlassian.net/browse/AMW-628)