### PR TITLE
Replace deprecated community.general.yaml callback with result

### DIFF
--- a/molecule/sso_test/molecule.yml
+++ b/molecule/sso_test/molecule.yml
@@ -14,7 +14,8 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
+      callback_result_format: yaml
     ssh_connection:
       pipelining: false
   playbooks:


### PR DESCRIPTION
To fix:

[WARNING]: Deprecation warnings can be disabled by setting
    │   `deprecation_warnings=False` in ansible.cfg.
    │ [DEPRECATION WARNING]: community.general.yaml has been deprecated. The
    │   plugin has been superseded by the option `result_format=yaml` in callback
    │   plugin ansible.builtin.default from ansible-core 2.13 onwards. This
    │   feature will be removed from collection 'community.general' version
    │   12.0.0.


[AMW-578](https://redhat.atlassian.net/browse/AMW-578)